### PR TITLE
style: clarify renderCalendar match day logic

### DIFF
--- a/game.js
+++ b/game.js
@@ -232,16 +232,15 @@ function renderCalendar(){
     item.innerHTML=`<div class="muted">${dateStr}</div><div class="dot"></div>${label}${extra||''}`;
 
     if(entry && entry.isMatch){
-    if(sameDay(entry.date, st.currentDate)){
-      item.style.cursor='pointer';
-      item.title = entry.played ? 'View match summary' : 'Play match';
-      item.onclick = ()=> entry.played ? viewMatchSummary(entry) : openMatch(entry);
-    }
-    // add this else-if:
-    else if(entry.played){
-      item.style.cursor='pointer';
-      item.title='View match summary';
-      item.onclick=()=> viewMatchSummary(entry);
+      if(sameDay(entry.date, st.currentDate)){
+        item.style.cursor='pointer';
+        item.title = entry.played ? 'View match summary' : 'Play match';
+        item.onclick = ()=> entry.played ? viewMatchSummary(entry) : openMatch(entry);
+      }
+      else if(entry.played){
+        item.style.cursor='pointer';
+        item.title='View match summary';
+        item.onclick=()=> viewMatchSummary(entry);
       }
     }
     grid.append(item);


### PR DESCRIPTION
## Summary
- remove stray comment from `renderCalendar`
- re-indent match-day conditional blocks for clarity

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e40669b4832dac41a4f0f31860ae