### PR TITLE
Inject app version at runtime

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,7 +1,10 @@
 /* WebCareerGame • Pre‑Alpha v0.0.3
-   External JS (state, sim, UI). Mobile + desktop safe.  
+   External JS (state, sim, UI). Mobile + desktop safe.
    Keep gameplay deterministic enough for testing but fun.
 */
+
+// Version string injected into the UI and document title.
+const APP_VERSION = 'v0.0.3';
 
 // ===== Storage / Globals =====
 const LS_KEY = 'webcareergame.save.v003';
@@ -248,6 +251,13 @@ function renderCalendar(){
 }
 
 function renderLiveLog(){ const el=q('#live-log'); if(!el) return; const st=Game.state; const last=st.eventLog.slice(-30); el.textContent=last.join('\n'); }
+
+function injectVersion(){
+  document.title = document.title.replace(/v[\d.]+/, APP_VERSION);
+  document.querySelectorAll('.app-version').forEach(el => {
+    el.textContent = APP_VERSION;
+  });
+}
 
 // ===== Market UI =====
 function openMarket(){
@@ -523,6 +533,7 @@ function wireEvents(){
 
 (function boot(){
   wireEvents();
+  injectVersion();
   if(!Game.load()){
     console.warn('Failed to load save state; starting fresh');
   }

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <div class="container brand">
       <div class="logo" aria-hidden="true"></div>
       <h1>WebCareerGame</h1>
-      <div class="version">Pre-Alpha v0.0.3</div>
+      <div class="version">Pre-Alpha <span class="app-version"></span></div>
     </div>
   </header>
 
@@ -28,7 +28,7 @@
           <div class="row spread">
             <div>
               <div class="h">Current version</div>
-              <div class="row pills"><span class="pill">v0.0.3</span><span class="pill">pre-alpha</span><span class="pill">auto-advance + season</span></div>
+              <div class="row pills"><span class="pill"><span class="app-version"></span></span><span class="pill">pre-alpha</span><span class="pill">auto-advance + season</span></div>
             </div>
             <button class="btn ghost" id="btn-reset" title="Clear local save">Reset save</button>
           </div>
@@ -153,7 +153,7 @@
     </section>
   </main>
 
-  <footer class="container app-footer">v0.0.3 • pre-alpha • made for fun</footer>
+  <footer class="container app-footer"><span class="app-version"></span> • pre-alpha • made for fun</footer>
 
   <!-- Market modal -->
   <dialog id="market-modal" class="modal">


### PR DESCRIPTION
## Summary
- expose `APP_VERSION` constant and helper to inject version info into the DOM
- replace hard-coded version strings in HTML with runtime placeholders

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8bb6518832db2435c4bbd799af3