### PR TITLE
feat: add training sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,6 +107,7 @@
             <div class="h">Actions</div>
             <div class="row wrap">
               <button class="btn" id="btn-market">Market</button>
+              <button class="btn" id="btn-train">Train</button>
               <button class="btn ghost" id="btn-save">Save</button>
               <button class="btn danger" id="btn-retire">Retire</button>
               <button class="btn ghost" id="btn-log">Download log</button>
@@ -178,6 +179,17 @@
         <button class="btn ghost" id="close-match">Close</button>
       </header>
       <div class="content" id="match-content"></div>
+    </div>
+  </dialog>
+
+  <!-- Training modal -->
+  <dialog id="training-modal" class="modal">
+    <div class="sheet">
+      <header class="brand sheet-head">
+        <div class="logo"></div><h1 class="sheet-title">Training</h1>
+        <button class="btn ghost" id="close-training">Close</button>
+      </header>
+      <div class="content" id="training-content"></div>
     </div>
   </dialog>
 


### PR DESCRIPTION
## Summary
- add Train action and modal for running a training minigame
- boost overall and log events after completing training
- disable training on match days or when injured

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68a1edea96e0832d831ae50adcb7aabe