### PR TITLE
Add season standings table and manager message popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WebCareerGame • Pre-Alpha v0.0.4</title>
+  <title>WebCareerGame • Pre-Alpha v0.0.5</title>
   <!-- Split build: external CSS & JS -->
   <link rel="stylesheet" href="style.css">
   <script src="game.js" defer></script>
@@ -35,7 +35,7 @@
         </div>
 
         <div class="glass">
-          <div class="h">What's new</div>
+          <div class="h">What's new <span class="app-version"></span></div>
           <ul class="updates">
             <li>Next day simulates scheduled matches automatically.</li>
             <li>Includes all Premier League clubs.</li>
@@ -201,6 +201,17 @@
         <button class="btn ghost" id="retire-cancel">Cancel</button>
         <button class="btn danger" id="retire-confirm">Confirm retire</button>
       </div>
+    </div>
+  </dialog>
+
+  <!-- Message modal -->
+  <dialog id="message-modal" class="modal">
+    <div class="sheet">
+      <header class="brand sheet-head">
+        <div class="logo"></div><h1 class="sheet-title">Manager message</h1>
+        <button class="btn ghost" id="close-message">✕</button>
+      </header>
+      <div class="content" id="message-content"></div>
     </div>
   </dialog>
 </body>

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* WebCareerGame • Pre-Alpha v0.0.4
+/* WebCareerGame • Pre-Alpha v0.0.5
    External stylesheet (dark, minimalist, iOS‑ish)
    Mobile-first, responsive up to desktop
 */
@@ -220,6 +220,15 @@ a{ color:var(--primary) }
 /* Utilities */
 .hidden{display:none}
 .gold{color:var(--warning);font-weight:800}
+
+/* League table */
+.league-table{width:100%;border-collapse:collapse;margin-top:12px;font-size:14px}
+.league-table th,.league-table td{padding:4px 8px;text-align:center}
+.league-table thead{color:var(--text-dim)}
+.league-table tr:nth-child(even){background:var(--surface-2)}
+.league-table tr.highlight{background:rgba(78,156,255,.15)}
+.league-table td:first-child{text-align:right;width:32px}
+.league-table td:nth-child(2){text-align:left}
 
 /* Landing layout */
 .landing{display:grid;gap:16px}


### PR DESCRIPTION
## Summary
- Display current version in the What's new panel
- Replace season-end manager alert with a dismissible popup
- Compute league table from match results and show standings in season summary

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a23223e2b8832da73c82b7675a26d3