### PR TITLE
Expand shop with seasonal limits

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WebCareerGame • Pre-Alpha v0.0.5</title>
+  <title>WebCareerGame • Pre-Alpha v0.0.6</title>
   <!-- Split build: external CSS & JS -->
   <link rel="stylesheet" href="style.css">
   <script src="game.js" defer></script>
@@ -37,17 +37,19 @@
         <div class="glass">
           <div class="h">What's new <span class="app-version"></span></div>
           <ul class="updates">
-            <li>Next day simulates scheduled matches automatically.</li>
-            <li>Includes all Premier League clubs.</li>
-            <li>Match days vary between Wed and Sat.</li>
-            <li>Auto advance days: pauses on match days with a short delay.</li>
-            <li>Live event log panel under Notes.</li>
-            <li>Season start and season end days added with summary and next season rollover.</li>
-            <li>Offer variety: club budgets, contract length tradeoffs, position bonuses.</li>
-            <li>Landing option: "Always play" to force starting XI.</li>
+            <li>Club shop expanded with more items and purchase limits.</li>
+            <li>Sponsorship boosts salary for a season.</li>
+            <li>Houses provide passive weekly income across seasons.</li>
+            <li>Shop limits reset when a new season begins.</li>
           </ul>
           <div class="h before">Before</div>
-          <ul class="updates muted"><li>v0.0.2: retire flow, calendar protections, market respecting contracts, logs.</li></ul>
+          <ul class="updates muted">
+            <li>v0.0.5: auto-advance days, season summary, event log.</li>
+            <li>v0.0.4: contract offers, salary/value, market tweaks.</li>
+            <li>v0.0.3: training minigame and match simulation improvements.</li>
+            <li>v0.0.2: retire flow, calendar protections, market respecting contracts, logs.</li>
+            <li>v0.0.1: initial prototype.</li>
+          </ul>
         </div>
       </div>
 
@@ -109,6 +111,7 @@
             <div class="h">Actions</div>
             <div class="row wrap">
               <button class="btn" id="btn-market">Market</button>
+              <button class="btn" id="btn-shop">Shop</button>
               <button class="btn" id="btn-train">Train</button>
               <button class="btn ghost" id="btn-save">Save</button>
               <button class="btn danger" id="btn-retire">Retire</button>
@@ -187,6 +190,17 @@
         <button class="btn ghost" id="close-training">Close</button>
       </header>
       <div class="content" id="training-content"></div>
+    </div>
+  </dialog>
+
+  <!-- Shop modal -->
+  <dialog id="shop-modal" class="modal">
+    <div class="sheet">
+      <header class="brand sheet-head">
+        <div class="logo"></div><h1 class="sheet-title">Shop</h1>
+        <button class="btn ghost" id="close-shop">Close</button>
+      </header>
+      <div class="content" id="shop-content"></div>
     </div>
   </dialog>
 


### PR DESCRIPTION
## Summary
- Bump game to v0.0.6 and track shop purchases per season
- Add sponsorship and house items with salary multipliers and passive income
- Update What's New panel with earlier version history

## Testing
- `node --check game.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d5082c8832d9749dfa41513d9dd