### PR TITLE
feat: color calendar and log, expand shop

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WebCareerGame • Pre-Alpha v0.0.6</title>
+  <title>WebCareerGame • Pre-Alpha v0.0.7</title>
   <!-- Split build: external CSS & JS -->
   <link rel="stylesheet" href="style.css">
   <script src="game.js" defer></script>
@@ -37,10 +37,9 @@
         <div class="glass">
           <div class="h">What's new <span class="app-version"></span></div>
           <ul class="updates">
-            <li>Club shop expanded with more items and purchase limits.</li>
-            <li>Sponsorship boosts salary for a season.</li>
-            <li>Houses provide passive weekly income across seasons.</li>
-            <li>Shop limits reset when a new season begins.</li>
+            <li>Calendar highlights past results in green, red, or grey.</li>
+            <li>Event log colors paydays, signings, and match outcomes.</li>
+            <li>Expanded shop with clearer descriptions and extra items.</li>
           </ul>
           <div class="h before">Before</div>
           <ul class="updates muted">

--- a/style.css
+++ b/style.css
@@ -200,14 +200,26 @@ a{ color:var(--primary) }
 .day.match .dot{background:var(--primary);box-shadow:0 0 16px rgba(78,156,255,.8)}
 .day.today{outline:2px solid var(--accent)}
 .day.played{background:linear-gradient(180deg,#111a25,#0f1720)}
+.day.win{background:#102b16;border-color:#225a31;opacity:1}
+.day.loss{background:#2b1010;border-color:#5a2222;opacity:1}
+.day.draw{background:#1a1a1a;border-color:#444;opacity:1}
+.day.win .res{color:#3cb371}
+.day.loss .res{color:#d9534f}
+.day.draw .res{color:#bbb}
 
 /* Live log */
 .live-log{height:180px;overflow-y:auto;white-space:pre-line}
+.log-win{color:#3cb371}
+.log-loss{color:#d9534f}
+.log-draw{color:#bbb}
+.log-payday{color:#ffc107}
+.log-sign{color:#81b3ff}
 
 /* Modal */
 .modal{position:fixed;inset:0;display:none;align-items:center;justify-content:center;padding:16px}
 .modal[open]{display:flex}
 .modal .sheet{width:100%;max-width:760px;background:linear-gradient(180deg,#0f141b,#121923);border:1px solid var(--border);border-radius:16px;box-shadow:0 40px 80px rgba(0,0,0,.6);color:var(--text)}
+#shop-modal .sheet{max-width:900px}
 .sheet-head{padding:10px 16px}
 .sheet-title{font-size:16px}
 .sheet .content{padding:16px}
@@ -216,6 +228,9 @@ a{ color:var(--primary) }
 /* Minigame */
 .minigame{position:relative;width:100%;height:260px;border-radius:12px;background:#0e1620;border:1px dashed var(--border);overflow:hidden}
 .bubble{position:absolute;width:34px;height:34px;border-radius:999px;background:linear-gradient(180deg,#2a6df1,#204fb3);display:grid;place-items:center;font-weight:900;user-select:none;cursor:pointer}
+
+.shop-item{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}
+.shop-item .desc{font-size:12px;margin-top:4px}
 
 /* Utilities */
 .hidden{display:none}


### PR DESCRIPTION
## Summary
- show past match results in calendar colors and highlight payday, signing, win/loss/draw events in log
- enlarge shop modal with clearer item descriptions and new items like gym membership and sports car
- bump version to v0.0.7

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a248670c08832dbe91bfa6a63e96cc