### PR TITLE
Fix season rollover and highlight league table

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -29,6 +29,7 @@ const Game = {
     shopPurchases: {},
     auto: false,
     lastTrainingDate: null,
+    seasonProcessed: false,
   },
   money(n){ try { return '£' + Math.round(n).toLocaleString('en-GB'); } catch { return '£' + Math.round(n); } },
   save(){ localStorage.setItem(LS_KEY, JSON.stringify(this.state)); },
@@ -76,6 +77,7 @@ const Game = {
     this.state.shopPurchases = {};
     this.state.auto = false;
     this.state.lastTrainingDate = null;
+    this.state.seasonProcessed = false;
     const year = new Date().getFullYear();
     const first = randomWedToSatOfWeek(lastSaturdayOfAugust(year));
     this.state.schedule = buildSchedule(first, 38);
@@ -93,6 +95,7 @@ function migrateState(st){
   st.shopPurchases = st.shopPurchases || {};
   st.auto = !!st.auto;
   st.lastTrainingDate = st.lastTrainingDate || null;
+  st.seasonProcessed = !!st.seasonProcessed;
   if(st.player){
     st.player.salaryMultiplier = st.player.salaryMultiplier || 1;
     st.player.passiveIncome = st.player.passiveIncome || 0;

--- a/js/season.js
+++ b/js/season.js
@@ -1,6 +1,9 @@
 // ===== Season end summary & rollover =====
 function openSeasonEnd(){
   const st=Game.state;
+  if(st.seasonProcessed) return;
+  st.seasonProcessed = true;
+  Game.save();
 
   // compute player's team stats from season
   const stats={w:0,d:0,l:0,gf:0,ga:0};
@@ -44,7 +47,16 @@ function openSeasonEnd(){
     }
   }
 
-  const rows=teams.map((t,i)=>`<tr${t.team===club?' class="highlight"':''}><td>${i+1}</td><td>${t.team}</td><td>${t.w}</td><td>${t.d}</td><td>${t.l}</td><td>${t.gf}</td><td>${t.ga}</td><td>${t.pts}</td></tr>`).join('');
+  const rows=teams.map((t,i)=>{
+    const cls=[];
+    if(t.team===club) cls.push('highlight');
+    if(i===0) cls.push('pos1');
+    else if(i===1) cls.push('pos2');
+    else if(i===2) cls.push('pos3');
+    else if(i===3 || i===4) cls.push('pos4-5');
+    else if(i>=17) cls.push('pos-bottom');
+    return `<tr${cls.length?` class="${cls.join(' ')}"`:''}><td>${i+1}</td><td>${t.team}</td><td>${t.w}</td><td>${t.d}</td><td>${t.l}</td><td>${t.gf}</td><td>${t.ga}</td><td>${t.pts}</td></tr>`;
+  }).join('');
   const tableHtml=`<table class="league-table"><thead><tr><th>Pos</th><th>Team</th><th>W</th><th>D</th><th>L</th><th>GF</th><th>GA</th><th>Pts</th></tr></thead><tbody>${rows}</tbody></table>`;
 
   const c=q('#match-content'); c.innerHTML='';
@@ -79,6 +91,7 @@ function openSeasonEnd(){
     st.seasonMinutes=0; st.seasonGoals=0; st.seasonAssists=0;
     Object.keys(st.shopPurchases||{}).forEach(id=>{ const it=SHOP_ITEMS.find(i=>i.id===id); if(it && it.perSeason) delete st.shopPurchases[id]; });
     st.player.salaryMultiplier=1;
+    st.seasonProcessed = false;
     Game.log(`Season ${st.season} begins. Age ${st.player.age}. Contract ${st.player.yearsLeft} season${st.player.yearsLeft!==1?'s':''} left.`);
     Game.state.auto=false; updateAutoBtn();
     Game.save(); renderAll();

--- a/js/ui.js
+++ b/js/ui.js
@@ -57,7 +57,6 @@ function renderAll(){
   }
   else if(todayEntry && todayEntry.type==='seasonEnd'){
     q('#week-summary').textContent = 'Season ended. View summary and continue.';
-    if(cta) cta.append(btn('Season summary', ()=>openSeasonEnd()));
   }
   else if(todayEntry && todayEntry.isMatch){
     q('#week-summary').innerHTML = `Match day: ${st.player.club} vs ${todayEntry.opponent}<div class="muted" style="font-size:11px"></div>`;

--- a/style.css
+++ b/style.css
@@ -252,9 +252,15 @@ a{ color:var(--primary) }
 .league-table th,.league-table td{padding:4px 8px;text-align:center}
 .league-table thead{color:var(--text-dim)}
 .league-table tr:nth-child(even){background:var(--surface-2)}
-.league-table tr.highlight{background:rgba(78,156,255,.15)}
+.league-table tr.highlight{outline:2px solid var(--primary)}
 .league-table td:first-child{text-align:right;width:32px}
 .league-table td:nth-child(2){text-align:left}
+
+.league-table tr.pos1{background:linear-gradient(180deg,#ffd700,#b8860b)}
+.league-table tr.pos2{background:rgba(192,192,192,.4)}
+.league-table tr.pos3{background:rgba(205,127,50,.4)}
+.league-table tr.pos4-5{background:rgba(78,156,255,.2)}
+.league-table tr.pos-bottom{background:rgba(255,122,122,.25)}
 
 /* Landing layout */
 .landing{display:grid;gap:16px}


### PR DESCRIPTION
## Summary
- Avoid duplicate season summary button at season end
- Prevent auto-advance from voiding remaining contract years
- Color code league table rows for finishing positions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a38b2a31a4832d9b5f9853112073dd