### PR TITLE
feat: add team levels and season summary fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WebCareerGame • Pre-Alpha v0.0.8</title>
+  <title>WebCareerGame • Pre-Alpha v0.0.9</title>
   <!-- Split build: external CSS & JS -->
   <link rel="stylesheet" href="style.css">
   <script src="js/core.js" defer></script>

--- a/js/market.js
+++ b/js/market.js
@@ -28,6 +28,7 @@ function openMarket(){
             <span class="pill">${o.years} season${o.years>1?'s':''}</span>
             <span class="pill">${o.status}</span>
             <span class="pill">${o.timeBand}</span>
+            <span class="pill">Lvl ${o.level||getTeamLevel(o.club)}</span>
             <span class="pill">${Game.money(o.salary)}/week</span>
             <span class="pill">value ${fmtValue(o.value)}</span>
           </div>

--- a/js/match.js
+++ b/js/match.js
@@ -128,8 +128,11 @@ function finishMatch(entry, minutes, mini){
     assists = Math.random()<baseA+perfBoost ? 1 : 0;
   }
   // Team scoreline
-  const teamBase=Math.max(0, Math.round(randNorm(1.4,1.0)));
-  const oppBase =Math.max(0, Math.round(randNorm(1.2,1.0)));
+  const myLvl=getTeamLevel(st.player.club);
+  const oppLvl=getTeamLevel(entry.opponent);
+  const diff=(myLvl-oppLvl)/20; // level difference biases score
+  const teamBase=Math.max(0, Math.round(randNorm(1.4+diff,1.0)));
+  const oppBase =Math.max(0, Math.round(randNorm(1.2-diff,1.0)));
   const teamGoals=teamBase+(goals>0?1:0);
   const oppGoals =oppBase;
   const result=teamGoals>oppGoals?'W': teamGoals<oppGoals?'L':'D';
@@ -179,8 +182,11 @@ function simulateMatch(entry){
     goals = Math.random()<baseG+perfBoost ? (Math.random()<0.12?2:1) : 0;
     assists = Math.random()<baseA+perfBoost ? 1 : 0;
   }
-  const teamBase=Math.max(0, Math.round(randNorm(1.4,1.0)));
-  const oppBase=Math.max(0, Math.round(randNorm(1.2,1.0)));
+  const myLvl=getTeamLevel(st.player.club);
+  const oppLvl=getTeamLevel(entry.opponent);
+  const diff=(myLvl-oppLvl)/20;
+  const teamBase=Math.max(0, Math.round(randNorm(1.4+diff,1.0)));
+  const oppBase=Math.max(0, Math.round(randNorm(1.2-diff,1.0)));
   const teamGoals=teamBase+(goals>0?1:0);
   const oppGoals=oppBase;
   const result=teamGoals>oppGoals?'W': teamGoals<oppGoals?'L':'D';

--- a/js/ui.js
+++ b/js/ui.js
@@ -15,6 +15,7 @@ function renderAll(){
   q('#landing').style.display = onLanding ? 'grid' : 'none';
   q('#manager').style.display = onLanding ? 'none' : 'block';
   if(onLanding) return;
+  updateLeagueSnapshot();
 
   // Left info
   q('#v-name').textContent = st.player.name;
@@ -63,6 +64,16 @@ function renderAll(){
   }
   else{
     q('#week-summary').textContent = 'Training and recovery. Prepare for the next game.';
+  }
+
+  if(st.player.club!=='Free Agent' && st.leagueSnapshot && st.leagueSnapshot.length){
+    const pos = st.leagueSnapshot.findIndex(t=>t.team===st.player.club)+1;
+    const leader = st.leagueSnapshot[0];
+    const info = document.createElement('div');
+    info.className='muted';
+    info.style.fontSize='12px';
+    info.textContent = `Table: ${pos}/20 • Leader ${leader.team} ${leader.pts} pts`;
+    q('#week-summary').append(info);
   }
 
   const trainBtn=q('#btn-train');


### PR DESCRIPTION
## Summary
- introduce club strength levels that influence contracts, matches and dynamic growth
- allow reopening season-end summary and adjust club levels based on table finish
- show current league position and leader; expose club level in transfer offers

## Testing
- `node --check js/core.js js/market.js js/match.js js/season.js js/ui.js`

------
https://chatgpt.com/codex/tasks/task_e_68a38efa894c832da3cf9877a0ed44d6