### PR TITLE
Refresh UI when auto stops at season end

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -4,7 +4,7 @@ function toggleAuto(){ Game.state.auto=!Game.state.auto; Game.save(); updateAuto
 function autoTick(){
   if(!Game.state.auto) return;
   const entry = Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate));
-  if(entry && entry.type==='seasonEnd'){ Game.state.auto=false; updateAutoBtn(); return; }
+  if(entry && entry.type==='seasonEnd'){ Game.state.auto=false; updateAutoBtn(); renderAll(); return; }
   setTimeout(()=>{ if(Game.state.auto){ nextDay(); } }, 800+Math.floor(Math.random()*600));
 }
 function nextDay(){


### PR DESCRIPTION
## Summary
- Re-render the UI when auto-advance stops at season end so the Season summary button is enabled

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a392abf3f8832d9cb5a990fd3bfff8