### PR TITLE
Fix league summary snapshot after season end

### DIFF
--- a/js/season.js
+++ b/js/season.js
@@ -66,6 +66,10 @@ function openSeasonEnd(){
     });
     teams.sort((a,b)=>b.pts-a.pts || (b.gf-b.ga)-(a.gf-a.ga));
 
+    // snapshot final table for consistency in week summary
+    st.leagueSnapshot = teams.map(t=>({...t}));
+    st.leagueSnapshotWeek = 38;
+
     // adjust team levels based on final positions
     teams.forEach((t,i)=>{
       const lvl=getTeamLevel(t.team);


### PR DESCRIPTION
## Summary
- Capture final league table at season end to keep week summary info in sync with season summary modal.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a3ac25411c832dbb3af6d4f1f03d98