### PR TITLE
feat: add contract renewal and rework system

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
   <script src="js/core.js" defer></script>
   <script src="js/ui.js" defer></script>
   <script src="js/market.js" defer></script>
+  <script src="js/contract.js" defer></script>
   <script src="js/shop.js" defer></script>
   <script src="js/match.js" defer></script>
   <script src="js/season.js" defer></script>
@@ -121,6 +122,7 @@
               <button class="btn primary" id="btn-market">🛒 Market</button>
               <button class="btn primary" id="btn-shop">🏪 Shop</button>
               <button class="btn primary" id="btn-train">🏋️‍♂️ Train</button>
+              <button class="btn primary" id="btn-contract">📝 Contract</button>
             </div>
             <div class="row wrap mt">
               <button class="btn ghost" id="btn-save">💾 Save</button>

--- a/js/contract.js
+++ b/js/contract.js
@@ -1,0 +1,35 @@
+// ===== Contract rework =====
+function statusRank(s){ return ['rookie','decent','key player','important','star player'].indexOf(s); }
+function timeRank(t){ return ['second bench','bench','rotater','match player','match starter'].indexOf(t); }
+function openContractRework(){
+  const st=Game.state;
+  if(st.player.club==='Free Agent'){ alert('You have no contract.'); return; }
+  if(st.player.contractReworkYear>=st.season){ alert('You already requested this season.'); return; }
+  if(st.player.marketBlocked>0){ alert(`Contract locked for ${st.player.marketBlocked} more season${st.player.marketBlocked>1?'s':''}.`); return; }
+  const salary=+prompt('Desired weekly salary?', st.player.salary) || st.player.salary;
+  const years=+prompt('Desired contract length (years)?', st.player.yearsLeft) || st.player.yearsLeft;
+  const status=prompt('Desired status?', st.player.status) || st.player.status;
+  const time=prompt('Desired time band?', st.player.timeBand) || st.player.timeBand;
+  const maxSalary=computeSalary(st.player.age, st.player.overall, st.player.league||'Premier League', status, time);
+  if(salary>maxSalary*1.2){ alert('Club rejects your unrealistic salary demand.'); st.player.contractReworkYear=st.season; Game.log('Contract rework rejected: salary too high.'); Game.save(); return; }
+  let chance=0.6;
+  if(salary>st.player.salary*1.1) chance-=0.2;
+  if(years>st.player.yearsLeft) chance-=0.1*(years-st.player.yearsLeft);
+  if(statusRank(status)>statusRank(st.player.status)) chance-=0.1;
+  if(timeRank(time)>timeRank(st.player.timeBand)) chance-=0.1;
+  if(Math.random()<chance){
+    st.player.salary=Math.round(salary);
+    st.player.yearsLeft=years;
+    st.player.status=status;
+    st.player.timeBand=time;
+    st.player.releaseClause=Math.round(st.player.value*(1.2+years*0.1));
+    Game.log('Club accepted contract rework');
+    alert('Club accepted your proposal.');
+  } else {
+    if(Math.random()<0.2){ st.player.transferListed=true; Game.log('Club rejected and listed you for transfer'); }
+    Game.log('Club rejected contract rework');
+    alert('Club rejected your proposal.');
+  }
+  st.player.contractReworkYear=st.season;
+  Game.save(); renderAll();
+}

--- a/js/main.js
+++ b/js/main.js
@@ -33,6 +33,7 @@ function wireEvents(){
   const click = (id, fn)=>{ const el=q(id); if(el) el.onclick=fn; };
   click('#btn-market', ()=>openMarket());
   click('#btn-shop', ()=>openShop());
+  click('#btn-contract', ()=>openContractRework());
   click('#close-market', ()=>q('#market-modal').removeAttribute('open'));
   click('#close-shop', ()=>q('#shop-modal').removeAttribute('open'));
   click('#btn-next', ()=>nextDay());

--- a/js/match.js
+++ b/js/match.js
@@ -130,7 +130,8 @@ function finishMatch(entry, minutes, mini){
   // Team scoreline
   const myLvl=getTeamLevel(st.player.club);
   const oppLvl=getTeamLevel(entry.opponent);
-  const diff=(myLvl-oppLvl)/20; // level difference biases score
+  let diff=(myLvl-oppLvl)/20; // level difference biases score
+  if(myLvl<75) diff+=(75-myLvl)/50; // boost low level teams
   const teamBase=Math.max(0, Math.round(randNorm(1.4+diff,1.0)));
   const oppBase =Math.max(0, Math.round(randNorm(1.2-diff,1.0)));
   const teamGoals=teamBase+(goals>0?1:0);
@@ -184,7 +185,8 @@ function simulateMatch(entry){
   }
   const myLvl=getTeamLevel(st.player.club);
   const oppLvl=getTeamLevel(entry.opponent);
-  const diff=(myLvl-oppLvl)/20;
+  let diff=(myLvl-oppLvl)/20;
+  if(myLvl<75) diff+=(75-myLvl)/50;
   const teamBase=Math.max(0, Math.round(randNorm(1.4+diff,1.0)));
   const oppBase=Math.max(0, Math.round(randNorm(1.2-diff,1.0)));
   const teamGoals=teamBase+(goals>0?1:0);


### PR DESCRIPTION
## Summary
- boost win odds and growth when playing for low level clubs
- add season-end contract renewal options with release clauses and market locks
- introduce contract rework action allowing players to renegotiate terms

## Testing
- `node --check js/core.js js/match.js js/market.js js/season.js js/contract.js js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b0eff414832dbe4e3377b2a9e876