### PR TITLE
Replace native alerts with reusable popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,6 +237,7 @@
         <button class="btn ghost" id="close-message">✕</button>
       </header>
       <div class="content" id="message-content"></div>
+      <div class="content sheet-actions" id="message-actions"></div>
     </div>
   </dialog>
 </body>

--- a/js/contract.js
+++ b/js/contract.js
@@ -3,15 +3,15 @@ function statusRank(s){ return ['rookie','decent','key player','important','star
 function timeRank(t){ return ['second bench','bench','rotater','match player','match starter'].indexOf(t); }
 function openContractRework(){
   const st=Game.state;
-  if(st.player.club==='Free Agent'){ alert('You have no contract.'); return; }
-  if(st.player.contractReworkYear>=st.season){ alert('You already requested this season.'); return; }
-  if(st.player.marketBlocked>0){ alert(`Contract locked for ${st.player.marketBlocked} more season${st.player.marketBlocked>1?'s':''}.`); return; }
+  if(st.player.club==='Free Agent'){ showPopup('Contract', 'You have no contract.'); return; }
+  if(st.player.contractReworkYear>=st.season){ showPopup('Contract', 'You already requested this season.'); return; }
+  if(st.player.marketBlocked>0){ showPopup('Contract', `Contract locked for ${st.player.marketBlocked} more season${st.player.marketBlocked>1?'s':''}.`); return; }
   const salary=+prompt('Desired weekly salary?', st.player.salary) || st.player.salary;
   const years=+prompt('Desired contract length (years)?', st.player.yearsLeft) || st.player.yearsLeft;
   const status=prompt('Desired status?', st.player.status) || st.player.status;
   const time=prompt('Desired time band?', st.player.timeBand) || st.player.timeBand;
   const maxSalary=computeSalary(st.player.age, st.player.overall, st.player.league||'Premier League', status, time);
-  if(salary>maxSalary*1.2){ alert('Club rejects your unrealistic salary demand.'); st.player.contractReworkYear=st.season; Game.log('Contract rework rejected: salary too high.'); Game.save(); return; }
+  if(salary>maxSalary*1.2){ showPopup('Contract', 'Club rejects your unrealistic salary demand.'); st.player.contractReworkYear=st.season; Game.log('Contract rework rejected: salary too high.'); Game.save(); return; }
   let chance=0.6;
   if(salary>st.player.salary*1.1) chance-=0.2;
   if(years>st.player.yearsLeft) chance-=0.1*(years-st.player.yearsLeft);
@@ -24,11 +24,11 @@ function openContractRework(){
     st.player.timeBand=time;
     st.player.releaseClause=Math.round(st.player.value*(1.2+years*0.1));
     Game.log('Club accepted contract rework');
-    alert('Club accepted your proposal.');
+    showPopup('Contract', 'Club accepted your proposal.');
   } else {
     if(Math.random()<0.2){ st.player.transferListed=true; Game.log('Club rejected and listed you for transfer'); }
     Game.log('Club rejected contract rework');
-    alert('Club rejected your proposal.');
+    showPopup('Contract', 'Club rejected your proposal.');
   }
   st.player.contractReworkYear=st.season;
   Game.save(); renderAll();

--- a/js/main.js
+++ b/js/main.js
@@ -41,8 +41,8 @@ function wireEvents(){
   click('#btn-train', ()=>openTraining());
   click('#close-training', ()=>q('#training-modal').removeAttribute('open'));
   click('#btn-play', ()=>{ const entry=Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate)); if(entry && entry.isMatch && !entry.played) openMatch(entry); });
-  click('#btn-save', ()=>{ Game.save(); alert('Saved'); });
-  click('#btn-reset', ()=>{ if(confirm('Delete your local save and restart')) Game.reset(); });
+  click('#btn-save', ()=>{ Game.save(); showPopup('Save', 'Game saved'); });
+  click('#btn-reset', ()=>{ showPopup('Reset save', 'Delete your local save and restart?', ()=>Game.reset()); });
   click('#btn-retire', ()=>retirePrompt());
   click('#retire-cancel', ()=>q('#retire-modal').removeAttribute('open'));
   click('#retire-confirm', ()=>{ q('#retire-modal').removeAttribute('open'); Game.reset(); });

--- a/js/market.js
+++ b/js/market.js
@@ -11,8 +11,8 @@ function openMarket(){
         if(st.player.transferListed){ st.lastOffers = Math.random()<0.6 ? rollMarketOffers(st.player) : []; }
         else {
           const approve = Math.random()<0.6; // 60% approve
-          if(approve){ st.player.transferListed=true; Game.log('Club approved transfer listing'); alert('Your club listed you for transfer.'); }
-          else { Game.log('Club denied transfer request'); alert('Club denied your request right now. Perform well and ask again.'); }
+          if(approve){ st.player.transferListed=true; Game.log('Club approved transfer listing'); showPopup('Transfer market', 'Your club listed you for transfer.'); }
+          else { Game.log('Club denied transfer request'); showPopup('Transfer market', 'Club denied your request right now. Perform well and ask again.'); }
         }
         Game.save(); renderAll(); openMarket();
       }, 'btn primary');

--- a/js/match.js
+++ b/js/match.js
@@ -62,9 +62,9 @@ function openTraining(){
   const todayEntry = st.schedule.find(d=>sameDay(d.date, st.currentDate));
   const injured = st.player.status && st.player.status.toLowerCase().includes('injur');
   const daysSince = st.lastTrainingDate ? (st.currentDate - st.lastTrainingDate)/(24*3600*1000) : Infinity;
-  if(todayEntry && todayEntry.isMatch){ alert('Match scheduled today. Focus on the game.'); return; }
-  if(injured){ alert('You are injured and cannot train.'); return; }
-  if(daysSince < 2){ alert(`Training available in ${Math.ceil(2-daysSince)} day(s).`); return; }
+  if(todayEntry && todayEntry.isMatch){ showPopup('Training', 'Match scheduled today. Focus on the game.'); return; }
+  if(injured){ showPopup('Training', 'You are injured and cannot train.'); return; }
+  if(daysSince < 2){ showPopup('Training', `Training available in ${Math.ceil(2-daysSince)} day(s).`); return; }
   const c=q('#training-content'); if(c) c.innerHTML='';
   const box=document.createElement('div');
   box.innerHTML='<div class="title">Training session</div>';

--- a/js/season.js
+++ b/js/season.js
@@ -125,7 +125,7 @@ function openSeasonEnd(){
     } else if(lastSeason.min<600){
       msg='Tough season. Salary stays the same.';
     }
-    showMessage(msg);
+    showPopup('Manager', msg);
     Game.log(`Manager: ${msg}`);
 
     if(st.player.club!=='Free Agent'){

--- a/js/shop.js
+++ b/js/shop.js
@@ -32,13 +32,13 @@ function buyItem(item){
   const st=Game.state;
   const purchases = st.shopPurchases || (st.shopPurchases = {});
   const count=purchases[item.id]||0;
-  if(count>=item.limit){ alert('Item limit reached.'); return; }
-  if((st.player.balance||0)<item.cost){ alert('Not enough funds.'); return; }
+  if(count>=item.limit){ showPopup('Shop', 'Item limit reached.'); return; }
+  if((st.player.balance||0)<item.cost){ showPopup('Shop', 'Not enough funds.'); return; }
   st.player.balance-=item.cost;
   purchases[item.id]=count+1;
   item.apply(st);
   Game.log(`Bought ${item.name} for ${Game.money(item.cost)}`);
-  showMessage(`Bought ${item.name}!`);
+  showPopup('Shop', `Bought ${item.name}!`);
   Game.save(); renderAll(); openShop();
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -3,10 +3,27 @@ function q(sel){ return document.querySelector(sel); }
 function btn(label, onClick, cls='btn primary'){ const b=document.createElement('button'); b.className=cls; b.textContent=label; b.onclick=onClick; return b; }
 function fmtValue(v){ if(v>=1_000_000) return '£'+(v/1_000_000).toFixed(1)+'m'; if(v>=1_000) return '£'+Math.round(v/100)/10+'k'; return Game.money(v); }
 
-function showMessage(msg){
+function showPopup(title, msg, onConfirm){
   const modal=q('#message-modal');
   const content=q('#message-content');
-  if(modal && content){ content.textContent=msg; modal.setAttribute('open',''); }
+  const titleEl=q('#message-modal .sheet-title');
+  const actions=q('#message-actions');
+  if(modal && content && titleEl && actions){
+    titleEl.textContent=title;
+    content.textContent=msg;
+    actions.innerHTML='';
+    if(onConfirm){
+      actions.append(
+        btn('Cancel', ()=>modal.removeAttribute('open'), 'btn ghost'),
+        btn('Confirm', ()=>{ modal.removeAttribute('open'); onConfirm(); })
+      );
+    } else {
+      actions.append(
+        btn('OK', ()=>modal.removeAttribute('open'))
+      );
+    }
+    modal.setAttribute('open','');
+  }
 }
 
 // ===== Rendering =====


### PR DESCRIPTION
## Summary
- Replace browser alerts with `showPopup` modal for consistent messaging
- Support confirm/cancel actions and OK buttons within popup
- Update save, shop, contract, market, and training flows to use new modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3b3c13ac0832d905cf37e06496489