### PR TITLE
Clamp match stats and unify salary handling

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -213,6 +213,10 @@ function computeValue(overall,league,weeklySalary){
   const fromSalary=weeklySalary*52*4; // salary-derived valuation proxy
   return Math.max(base, fromSalary);
 }
+
+function weeklySalary(p){
+  return Math.round((p.salary||0)*(p.salaryMultiplier||1));
+}
 function applyPostMatchGrowth(st, minutes, rating, goals, assists){
   const targetMap={'second bench':10,'bench':20,'rotater':45,'match player':70,'match starter':90};
   const target=targetMap[st.player.timeBand]||30; let delta=0;

--- a/js/season.js
+++ b/js/season.js
@@ -117,21 +117,34 @@ function openSeasonEnd(){
   q('#btn-next-season').onclick=()=>{
     q('#match-modal').removeAttribute('open');
     const lastSeason = {min:st.seasonMinutes, goals:st.seasonGoals, assists:st.seasonAssists};
-    // manager feedback
-    let msg='Well kid decent season, please work more.';
-    if(lastSeason.goals>=10 || lastSeason.min>=1800){
-      msg='Great season! Your salary increased.';
-      st.player.salary=Math.round(st.player.salary*1.1);
-    } else if(lastSeason.min<600){
-      msg='Tough season. Salary stays the same.';
-    }
-    showPopup('Manager', msg);
-    Game.log(`Manager: ${msg}`);
-
     if(st.player.club!=='Free Agent'){
+      // manager feedback
+      let msg;
+      if(lastSeason.goals>=10 || lastSeason.min>=1800){
+        st.player.salary=Math.round(st.player.salary*1.1);
+        msg=`Great season! Salary increased to ${Game.money(weeklySalary(st.player))}/w.`;
+      } else if(lastSeason.min<600){
+        msg=`Tough season. Salary stays the same at ${Game.money(weeklySalary(st.player))}/w.`;
+      } else {
+        msg=`Well kid decent season, salary stays at ${Game.money(weeklySalary(st.player))}/w.`;
+      }
+      showPopup('Manager', msg);
+      Game.log(`Manager: ${msg}`);
+
       st.player.yearsLeft = Math.max(0, st.player.yearsLeft-1);
-      if(st.player.yearsLeft<=0){ st.player.club='Free Agent'; st.player.league=''; st.player.status='-'; st.player.timeBand='-'; st.player.salary=0; Game.log('Contract ended. You are a Free Agent.'); }
-      st.player.marketBlocked = Math.max(0,(st.player.marketBlocked||0)-1);
+      if(st.player.yearsLeft<=0){
+        st.player.club='Free Agent';
+        st.player.league='';
+        st.player.status='-';
+        st.player.timeBand='-';
+        st.player.salary=0;
+        st.player.yearsLeft=0;
+        st.player.releaseClause=0;
+        st.player.marketBlocked=0;
+        Game.log('Contract ended. You are a Free Agent.');
+      } else {
+        st.player.marketBlocked = Math.max(0,(st.player.marketBlocked||0)-1);
+      }
       const poorSeason = lastSeason.min>900 && (lastSeason.goals+lastSeason.assists)<2;
       if(poorSeason && Math.random()<0.5){
         const lower=makeOpponents().filter(t=>getTeamLevel(t)<getTeamLevel(st.player.club));
@@ -157,7 +170,10 @@ function openSeasonEnd(){
     st.seasonSummary = null;
     st.leagueSnapshot = [];
     st.leagueSnapshotWeek = 0;
-    Game.log(`Season ${st.season} begins. Age ${st.player.age}. Contract ${st.player.yearsLeft} season${st.player.yearsLeft!==1?'s':''} left.`);
+    const contractInfo = st.player.club==='Free Agent'
+      ? 'Free Agent.'
+      : `Contract ${st.player.yearsLeft} season${st.player.yearsLeft!==1?'s':''} left.`;
+    Game.log(`Season ${st.season} begins. Age ${st.player.age}. ${contractInfo}`);
     Game.state.auto=false; updateAutoBtn();
     Game.save(); renderAll();
   };

--- a/js/ui.js
+++ b/js/ui.js
@@ -42,13 +42,24 @@ function renderAll(){
   else { q('#v-club').textContent = st.player.club; }
   q('#v-league').textContent = st.player.league || '-';
   q('#v-status').textContent = st.player.status;
-  q('#v-years').textContent = st.player.yearsLeft ? `${st.player.yearsLeft} season${st.player.yearsLeft>1?'s':''}` : '-';
+  const yearsEl=q('#v-years');
+  const yearsKey=yearsEl?yearsEl.previousElementSibling:null;
+  if(st.player.club==='Free Agent'){
+    if(yearsEl) yearsEl.style.display='none';
+    if(yearsKey) yearsKey.style.display='none';
+  } else {
+    if(yearsEl){
+      yearsEl.style.display='';
+      yearsEl.textContent = st.player.yearsLeft ? `${st.player.yearsLeft} season${st.player.yearsLeft>1?'s':''}` : '-';
+    }
+    if(yearsKey) yearsKey.style.display='';
+  }
 
   q('#v-season').textContent = st.season;
   q('#v-week').textContent = `${Math.min(st.week,38)} / 38`;
   q('#v-overall').textContent = st.player.overall;
   q('#v-playtime').textContent = `${st.minutesPlayed} min`;
-  const weeklyIncome = Math.round((st.player.salary||0)*(st.player.salaryMultiplier||1)+(st.player.passiveIncome||0));
+  const weeklyIncome = weeklySalary(st.player)+(st.player.passiveIncome||0);
   q('#v-salary').textContent = Game.money(weeklyIncome) + ' /week';
   q('#v-value').textContent = fmtValue(st.player.value);
   q('#v-balance').textContent = Game.money(st.player.balance||0);


### PR DESCRIPTION
## Summary
- Clamp player goals and assists to match the finalized team score and mark non-appearance with `DNP`
- Use a single weekly salary value across payroll, messages and UI
- Clear contract details and hide contract UI when the player is a free agent

## Testing
- `node --check webfccareermode/js/core.js`
- `node --check webfccareermode/js/match.js`
- `node --check webfccareermode/js/ui.js`
- `node --check webfccareermode/js/season.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3b907eb6c832d953e7056c0d46770