### PR TITLE
fix: block matches when free agent

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -16,6 +16,7 @@ function countdown(target, cb){
 
 function openMatch(entry){
   const st=Game.state; if(entry.played){ viewMatchSummary(entry); return; }
+  if(st.player.club==='Free Agent'){ showPopup('Match', 'You need a club to play matches.'); return; }
   if(!sameDay(entry.date, st.currentDate)) return; // only today
 
   const youStart = st.player.alwaysPlay ? true : decideStarting(st.player.timeBand);
@@ -171,6 +172,7 @@ function finishMatch(entry, minutes, mini){
 
 function simulateMatch(entry){
   const st=Game.state;
+  if(st.player.club==='Free Agent'){ showPopup('Match day', 'You need a club to play matches.'); return; }
   if(entry.played || !sameDay(entry.date, st.currentDate)) return;
   const youStart = st.player.alwaysPlay ? true : decideStarting(st.player.timeBand);
   const willSubIn = youStart?false:Math.random()<subChance(st.player.timeBand);

--- a/js/time.js
+++ b/js/time.js
@@ -10,7 +10,15 @@ function autoTick(){
 function nextDay(){
   const st=Game.state;
   const entry=st.schedule.find(d=>sameDay(d.date, st.currentDate));
-  if(entry && entry.isMatch && !entry.played){ simulateMatch(entry); return; }
+  if(entry && entry.isMatch && !entry.played){
+    if(st.player.club==='Free Agent'){
+      showPopup('Match day', 'You need a club to play matches.');
+      st.week = Math.min(38, st.week+1);
+      st.currentDate+=24*3600*1000; Game.save(); renderAll(); autoTick();
+      return;
+    }
+    simulateMatch(entry); return;
+  }
   if(entry && entry.type==='seasonEnd'){ Game.state.auto=false; updateAutoBtn(); openSeasonEnd(); return; }
   st.currentDate+=24*3600*1000; Game.save(); renderAll(); autoTick();
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -115,14 +115,17 @@ function renderAll(){
   const nextBtn=q('#btn-next');
   if(nextBtn){
     nextBtn.disabled = !!st.auto;
-    if(todayEntry && todayEntry.isMatch && !todayEntry.played) nextBtn.textContent='Simulate match';
+    if(todayEntry && todayEntry.isMatch && !todayEntry.played){
+      nextBtn.textContent = st.player.club==='Free Agent' ? 'Skip match' : 'Simulate match';
+    }
     else if(todayEntry && todayEntry.type==='seasonEnd') nextBtn.textContent='Season summary';
     else nextBtn.textContent='Next day';
   }
 
   const playBtn=q('#btn-play');
   if(playBtn){
-    if(todayEntry && todayEntry.isMatch && !todayEntry.played && !st.auto){
+    if(st.player.club==='Free Agent') playBtn.disabled=true;
+    else if(todayEntry && todayEntry.isMatch && !todayEntry.played && !st.auto){
       playBtn.disabled=false;
     } else {
       playBtn.disabled=true;


### PR DESCRIPTION
## Summary
- prevent free agents from playing or simulating matches
- disable play button and show skip match label when no club

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a3c3405970832d85d098608280319c