### PR TITLE
Freeze final league standings

### DIFF
--- a/js/season.js
+++ b/js/season.js
@@ -2,6 +2,8 @@
 function updateLeagueSnapshot(){
   const st=Game.state;
   if(!st.player || st.player.club==='Free Agent') return;
+  // Don't overwrite the final league table once the season is processed
+  if(st.seasonProcessed && st.week===38 && st.leagueSnapshotWeek===38) return;
   const played = st.schedule.filter(e=>e.isMatch && e.played).length;
   if(st.leagueSnapshotWeek===played) return;
   const club=st.player.club;

--- a/js/ui.js
+++ b/js/ui.js
@@ -32,7 +32,7 @@ function renderAll(){
   q('#landing').style.display = onLanding ? 'grid' : 'none';
   q('#manager').style.display = onLanding ? 'none' : 'block';
   if(onLanding) return;
-  updateLeagueSnapshot();
+  if(!(st.seasonProcessed && st.leagueSnapshotWeek===38)) updateLeagueSnapshot();
 
   // Left info
   q('#v-name').textContent = st.player.name;
@@ -100,7 +100,8 @@ function renderAll(){
     const info = document.createElement('div');
     info.className='muted';
     info.style.fontSize='12px';
-    info.textContent = `Table: ${pos}/20 • Leader ${leader.team} ${leader.pts} pts`;
+    const finalFlag = st.seasonProcessed && st.leagueSnapshotWeek===38 ? ' (final)' : '';
+    info.textContent = `Table: ${pos}/20${finalFlag} • Leader ${leader.team} ${leader.pts} pts`;
     q('#week-summary').append(info);
   }
 


### PR DESCRIPTION
## Summary
- Avoid recalculating league standings after the season is processed
- Skip snapshot updates and label the table as final when season ends

## Testing
- `node --check js/season.js`
- `node --check js/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68a3cea433bc832db00ae09f7aeeafad