### PR TITLE
Fix mobile calendar overlap by consolidating CSS

### DIFF
--- a/style.css
+++ b/style.css
@@ -162,17 +162,17 @@ h2{ font-size:var(--step-1); margin:8px 0 6px }
 .hud{ display:flex; gap:14px; flex-wrap:wrap; padding:8px 10px; background:var(--surface-2); border:1px solid var(--border); border-radius:12px }
 
 /* calendar */
-.calendar-grid{
+.calendar{
   margin-top:8px;
   display:grid; gap:8px;
   grid-template-columns: repeat(7, minmax(0, 1fr));
 }
 @media (max-width: 640px){
-  .calendar-grid{ grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .calendar{ grid-template-columns: repeat(4, minmax(0, 1fr)); }
 }
 .day{
   background:var(--surface-2); border:1px solid var(--border); border-radius:10px; padding:8px;
-  height:120px; display:flex; flex-direction:column; gap:4px; justify-content:space-between;
+  height:120px; display:flex; flex-direction:column; gap:4px; justify-content:space-between; text-align:center;
 }
 .day .date{ font-weight:600; font-size:12px; color:var(--text-dim) }
 .day.match{ border-color:rgba(255, 255, 255, 0.55); box-shadow: inset 0 0 0 1px rgba(154,166,255,.25) }
@@ -196,12 +196,8 @@ h2{ font-size:var(--step-1); margin:8px 0 6px }
 a{ color:var(--primary) }
 
 .week-panel{display:grid;gap:12px}
-.calendar{display:grid;grid-template-columns:repeat(7,1fr);gap:8px}
-.day{padding:10px;text-align:center;border-radius:10px;border:1px solid var(--border);background:#0f1720;font-size:12px;aspect-ratio:1;min-height:110px;display:flex;flex-direction:column;justify-content:center;align-items:center;gap:6px;overflow:hidden}
 .day .dot{width:8px;height:8px;border-radius:999px;margin:0 auto;background:var(--text-dim)}
 .day.match .dot{background:var(--primary);box-shadow:0 0 16px rgba(78,156,255,.8)}
-.day.today{outline:2px solid var(--accent)}
-.day.played{background:linear-gradient(180deg,#111a25,#0f1720)}
 .day.win{background:#102b16;border-color:#225a31;opacity:1}
 .day.loss{background:#2b1010;border-color:#5a2222;opacity:1}
 .day.draw{background:#1a1a1a;border-color:#444;opacity:1}


### PR DESCRIPTION
## Summary
- Remove duplicated calendar styles and unify around a single `.calendar` definition
- Make calendar grid responsive with mobile-friendly columns
- Ensure day cells are flexible and maintain win/loss indicators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3d85337e0832d8e3ea14c8f8a0b47