### PR TITLE
Fix training cancel bug and balance progression

### DIFF
--- a/js/contract.js
+++ b/js/contract.js
@@ -18,6 +18,9 @@ function contractChance(st,salary,years,status,time){
   if(years>st.player.yearsLeft) chance-=0.1*(years-st.player.yearsLeft);
   if(statusRank(status)>statusRank(st.player.status)) chance-=0.1;
   if(timeRank(time)>timeRank(st.player.timeBand)) chance-=0.1;
+  const avgMinutes = st.week>1 ? st.seasonMinutes/(st.week-1) : st.seasonMinutes;
+  const expect={'second bench':0,'bench':15,'rotater':40,'match player':65,'match starter':85}[time]||30;
+  if(avgMinutes < expect*0.5) chance-=0.3;
   return Math.max(0,chance);
 }
 function chanceClass(c){

--- a/js/main.js
+++ b/js/main.js
@@ -40,7 +40,7 @@ function wireEvents(){
   click('#btn-next', ()=>nextDay());
   click('#btn-auto', ()=>toggleAuto());
   click('#btn-train', ()=>openTraining());
-  click('#close-training', ()=>q('#training-modal').removeAttribute('open'));
+  click('#close-training', ()=>cancelTraining());
   click('#btn-play', ()=>{ const entry=Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate)); if(entry && entry.isMatch && !entry.played) openMatch(entry); });
   click('#btn-save', ()=>{ Game.save(); showPopup('Save', 'Game saved'); });
   click('#btn-reset', ()=>{ showPopup('Reset save', 'Delete your local save and restart?', ()=>Game.reset()); });

--- a/js/utils.js
+++ b/js/utils.js
@@ -82,7 +82,7 @@ function computeValue(overall,league,weeklySalary){
 function weeklySalary(p){
   return Math.round((p.salary||0)*(p.salaryMultiplier||1));
 }
-function applyPostMatchGrowth(st, minutes, rating, goals, assists){
+function applyPostMatchGrowth(st, minutes, rating, goals, assists, played){
   const targetMap={'second bench':10,'bench':20,'rotater':45,'match player':70,'match starter':90};
   const target=targetMap[st.player.timeBand]||30; let delta=0;
   if(minutes>=target) delta+=0.2; if(rating>=7) delta+=0.2; if(rating>=8) delta+=0.2;
@@ -92,6 +92,7 @@ function applyPostMatchGrowth(st, minutes, rating, goals, assists){
   if(minutes<target*.4) delta-=0.15; if(st.player.age>=31) delta-=0.05;
   const clubLvl=getTeamLevel(st.player.club);
   if(clubLvl<75) delta+=0.1; // lower level clubs boost growth
+  delta += played?0.1:-0.05;
   st.player.overall = Math.max(55, Math.min(100, +(st.player.overall+delta).toFixed(2)));
 }
 

--- a/style.css
+++ b/style.css
@@ -231,6 +231,7 @@ a{ color:var(--primary) }
 .sheet-title{font-size:16px}
 .sheet .content{padding:16px}
 .sheet-actions{display:flex;justify-content:flex-end;gap:8px;padding-top:0}
+#contract-salary-info{margin-top:4px;text-align:center}
 
 /* Minigame */
 .minigame{position:relative;width:100%;height:260px;border-radius:12px;background:#0e1620;border:1px dashed var(--border);overflow:hidden}


### PR DESCRIPTION
## Summary
- reset training session properly on cancel to avoid zero-gain bug and log cooldown requirement
- tighten contract approval by considering minutes played
- balance post-match overall growth, rewarding played matches more than simulations
- center contract salary info text

## Testing
- `npm test` *(fails: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68a4cefcdf90832da0e20b9917c4323e