### PR TITLE
Fix auto advance interfering with manual match flow

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -20,6 +20,7 @@ function countdown(target, cb){
 let trainingSession=null;
 
 function openMatch(entry){
+  clearAutoTick();
   const st=Game.state; if(entry.played){ viewMatchSummary(entry); return; }
   if(st.player.club==='Free Agent'){ showPopup('Match', 'You need a club to play matches.'); return; }
   if(!sameDay(entry.date, st.currentDate)) return; // only today
@@ -64,6 +65,7 @@ function openMatch(entry){
 }
 
 function openTraining(){
+  clearAutoTick();
   const st=Game.state;
   const todayEntry = st.schedule.find(d=>sameDay(d.date, st.currentDate));
   const injured = st.player.status && st.player.status.toLowerCase().includes('injur');

--- a/js/time.js
+++ b/js/time.js
@@ -1,25 +1,50 @@
 // ===== Time controls =====
+var autoTimeoutId=null; // pending auto tick timer
+var autoEpoch=0;        // generation token to invalidate queued ticks
+
+function modalOpen(){ return !!document.querySelector('.modal[open]'); }
+function clearAutoTick(){ if(autoTimeoutId){ clearTimeout(autoTimeoutId); autoTimeoutId=null; } autoEpoch++; }
+
 function updateAutoBtn(){ const b=q('#btn-auto'); if(!b) return; b.textContent = `Auto advance: ${Game.state.auto? 'On':'Off'}`; }
-function toggleAuto(){ Game.state.auto=!Game.state.auto; Game.save(); updateAutoBtn(); renderAll(); if(Game.state.auto) autoTick(); }
+function toggleAuto(){
+  Game.state.auto=!Game.state.auto;
+  Game.save();
+  updateAutoBtn();
+  renderAll();
+  if(Game.state.auto){
+    autoEpoch++; // start new generation
+    autoTick();
+  } else {
+    clearAutoTick();
+  }
+}
 function autoTick(){
   if(!Game.state.auto) return;
-  const entry = Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate));
-  if(entry && entry.type==='seasonEnd'){ Game.state.auto=false; updateAutoBtn(); renderAll(); return; }
-  setTimeout(()=>{ if(Game.state.auto){ nextDay(); } }, 800+Math.floor(Math.random()*600));
+  if(modalOpen()){ autoTimeoutId=setTimeout(autoTick,300); return; }
+  const token=autoEpoch;
+  autoTimeoutId=setTimeout(()=>{
+    autoTimeoutId=null;
+    if(Game.state.auto && token===autoEpoch && !modalOpen()){
+      nextDay(token);
+    }
+  }, 800+Math.floor(Math.random()*600));
 }
-function nextDay(){
+function nextDay(token){
+  if(token!==undefined){
+    if(token!==autoEpoch || !Game.state.auto || modalOpen()) return;
+  }
   const st=Game.state;
   const entry=st.schedule.find(d=>sameDay(d.date, st.currentDate));
   if(entry && entry.isMatch && !entry.played){
     if(st.player.club==='Free Agent'){
       showPopup('Match day', 'You need a club to play matches.');
       st.week = Math.min(38, st.week+1);
-      st.currentDate+=24*3600*1000; Game.save(); renderAll(); autoTick();
+      st.currentDate+=24*3600*1000; Game.save(); renderAll(); if(Game.state.auto) autoTick();
       return;
     }
     simulateMatch(entry); return;
   }
   if(entry && entry.type==='seasonEnd'){ Game.state.auto=false; updateAutoBtn(); openSeasonEnd(); return; }
-  st.currentDate+=24*3600*1000; Game.save(); renderAll(); autoTick();
+  st.currentDate+=24*3600*1000; Game.save(); renderAll(); if(Game.state.auto) autoTick();
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -126,7 +126,7 @@ function renderAll(){
   const playBtn=q('#btn-play');
   if(playBtn){
     if(st.player.club==='Free Agent') playBtn.disabled=true;
-    else if(todayEntry && todayEntry.isMatch && !todayEntry.played && !st.auto){
+    else if(todayEntry && todayEntry.isMatch && !todayEntry.played && !st.auto && !autoTimeoutId){
       playBtn.disabled=false;
     } else {
       playBtn.disabled=true;


### PR DESCRIPTION
## Summary
- track and clear auto-advance timers when auto is toggled off or a manual modal opens
- block auto-ticks while any modal is open and use a generation token to ignore stale timers
- enable Play button only when auto advance is fully idle

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e76804ec832d8a4608826670c250