### PR TITLE
Fix match minigame and log training cooldown

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -48,7 +48,10 @@ function openMatch(entry){
   c.append(wrap);
   const phase=q('#match-phase');
 
-  const startMini=(minutesPlanned)=>countdown(phase, ()=>requestAnimationFrame(()=>phase.append(minigameView('Make an impact in this moment!', res=>finishMatch(entry, minutesPlanned, res)))));
+  const startMini=(minutesPlanned)=>countdown(phase, ()=>requestAnimationFrame(()=>{
+    const mini=minigameView('Make an impact in this moment!', res=>finishMatch(entry, minutesPlanned, res));
+    phase.append(mini.el);
+  }));
   if(youStart){ startMini(90); }
   else if(willSubIn){
     const info=document.createElement('div'); info.className='glass';
@@ -74,7 +77,7 @@ function openTraining(){
   if(injured){ showPopup('Training', 'You are injured and cannot train.'); return; }
   if(daysSince < 2){
     const rest = Math.ceil(2-daysSince);
-    const msg=`You have already trained. You must rest ${rest} day${rest>1?'s':''} before training again.`;
+    const msg=`Tried to train but need to rest ${rest} day${rest>1?'s':''} before training again.`;
     Game.log(msg);
     showPopup('Training', `Training available in ${rest} day(s).`);
     return;


### PR DESCRIPTION
## Summary
- Ensure match minigame renders correctly by appending the created element
- Log a clear message when training is attempted before cooldown ends

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ea5934fc832da927f67c29a1ee85