### PR TITLE
Ensure training cooldown appears in live log

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -79,6 +79,8 @@ function openTraining(){
     const rest = Math.ceil(2-daysSince);
     const msg=`Tried to train but need to rest ${rest} day${rest>1?'s':''} before training again.`;
     Game.log(msg);
+    Game.save();
+    renderAll();
     showPopup('Training', `Training available in ${rest} day(s).`);
     return;
   }


### PR DESCRIPTION
## Summary
- Persist and render event log when attempting to train too soon
- Show training cooldown message in live log like other events

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ecee6e6c832d8537a0e798968e60