### PR TITLE
Add custom training cooldown popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -205,6 +205,20 @@
     </div>
   </dialog>
 
+  <!-- Training cooldown modal -->
+  <dialog id="cooldown-modal" class="modal">
+    <div class="sheet">
+      <header class="brand sheet-head">
+        <div class="logo"></div><h1 class="sheet-title">Rest day</h1>
+        <button class="btn ghost" id="close-cooldown">Close</button>
+      </header>
+      <div class="content" id="cooldown-content"></div>
+      <div class="content sheet-actions">
+        <button class="btn primary" id="cooldown-ok">OK</button>
+      </div>
+    </div>
+  </dialog>
+
   <!-- Shop modal -->
   <dialog id="shop-modal" class="modal">
     <div class="sheet">

--- a/js/main.js
+++ b/js/main.js
@@ -41,6 +41,8 @@ function wireEvents(){
   click('#btn-auto', ()=>toggleAuto());
   click('#btn-train', ()=>openTraining());
   click('#close-training', ()=>cancelTraining());
+  click('#close-cooldown', ()=>q('#cooldown-modal').removeAttribute('open'));
+  click('#cooldown-ok', ()=>q('#cooldown-modal').removeAttribute('open'));
   click('#btn-play', ()=>{ const entry=Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate)); if(entry && entry.isMatch && !entry.played) openMatch(entry); });
   click('#btn-save', ()=>{ Game.save(); showPopup('Save', 'Game saved'); });
   click('#btn-reset', ()=>{ showPopup('Reset save', 'Delete your local save and restart?', ()=>Game.reset()); });

--- a/js/match.js
+++ b/js/match.js
@@ -81,7 +81,7 @@ function openTraining(){
     Game.log(msg);
     Game.save();
     renderAll();
-    showPopup('Training', `Training available in ${rest} day(s).`);
+    showCooldownPopup(rest);
     return;
   }
   const c=q('#training-content'); if(c) c.innerHTML='';

--- a/js/ui.js
+++ b/js/ui.js
@@ -26,6 +26,15 @@ function showPopup(title, msg, onConfirm){
   }
 }
 
+function showCooldownPopup(rest){
+  const modal=q('#cooldown-modal');
+  const content=q('#cooldown-content');
+  if(modal && content){
+    content.textContent=`You need to rest ${rest} more day${rest>1?'s':''} before training again.`;
+    modal.setAttribute('open','');
+  }
+}
+
 // ===== Rendering =====
 function renderAll(){
   const st = Game.state; const onLanding = !st.player;


### PR DESCRIPTION
## Summary
- add dedicated dialog to notify players when training is on cooldown
- implement `showCooldownPopup` helper and hook it into training flow
- wire up event handlers for new cooldown modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ef49dd68832d82400795aa009097