### PR TITLE
feat: add goalkeeper update

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>WebCareerGame • Pre-Alpha v0.0.9</title>
+  <title>WebCareerGame • Pre-Alpha v0.1.0</title>
   <!-- Split build: external CSS & JS -->
   <link rel="stylesheet" href="style.css">
   <script src="js/game.js" defer></script>
@@ -12,6 +12,7 @@
   <script src="js/market.js" defer></script>
   <script src="js/contract.js" defer></script>
   <script src="js/shop.js" defer></script>
+  <script src="js/goalkeeper.js" defer></script>
   <script src="js/match.js" defer></script>
   <script src="js/season.js" defer></script>
   <script src="js/time.js" defer></script>
@@ -46,12 +47,12 @@
         <div class="glass">
           <div class="h">What's new <span class="app-version"></span></div>
           <ul class="updates">
-            <li>Play Match button lives beside Next day for stable layout.</li>
-            <li>Action buttons sport emojis with training cooldown and countdowns.</li>
-            <li>Calendar cells enlarged and centered for easier viewing.</li>
+            <li>Goalkeeper position playable with dedicated training and match minigames.</li>
+            <li>Goalkeeper contracts feature four tiers from backup to world-class.</li>
           </ul>
           <div class="h before">Before</div>
           <ul class="updates muted before-list">
+            <li>v0.0.9: Play Match beside Next day, action emojis with cooldowns, larger calendar cells.</li>
             <li>v0.0.7: calendar result colors, event log highlights, expanded shop.</li>
             <li>v0.0.6: refactored game scripts for modularity.</li>
             <li>v0.0.5: auto-advance days, season summary, event log.</li>
@@ -78,7 +79,7 @@
               <label class="pill radio"><input type="radio" name="pos" value="Attacker" checked> Attacker</label>
               <label class="pill radio"><input type="radio" name="pos" value="Midfield"> Midfield</label>
               <label class="pill radio"><input type="radio" name="pos" value="Defender"> Defender</label>
-              <label class="pill radio muted" title="Goalkeeper disabled" style="text-decoration: line-through;"><input type="radio" name="pos" value="Goalkeeper" disabled> Goalkeeper</label>
+              <label class="pill radio"><input type="radio" name="pos" value="Goalkeeper"> Goalkeeper <span class="badge new">NEW</span></label>
             </div>
           </div>
           <label class="pill checkbox"><input type="checkbox" id="always-play"> Always play</label>

--- a/js/contract.js
+++ b/js/contract.js
@@ -1,7 +1,19 @@
 // ===== Contract rework =====
-function statusRank(s){ return ['rookie','decent','key player','important','star player'].indexOf(s); }
+function statusRank(s){
+  const map={'rookie':0,'decent':1,'key player':2,'important':3,'star player':4,
+    'Backup keeper':0,'Reserve keeper':1,'First-choice':2,'World-class':3};
+  return map[s]??0;
+}
 function timeRank(t){ return ['second bench','bench','rotater','match player','match starter'].indexOf(t); }
-function allowedStatuses(age,overall,current){
+function allowedStatuses(age,overall,current,pos){
+  if(pos==='Goalkeeper'){
+    const list=['Backup keeper'];
+    if(overall>=60) list.push('Reserve keeper');
+    if(overall>=70) list.push('First-choice');
+    if(overall>=80) list.push('World-class');
+    if(current && !list.includes(current)) list.push(current);
+    return list;
+  }
   const list=['rookie'];
   if(overall>=60) list.push('decent');
   if(overall>=70) list.push('key player');
@@ -67,7 +79,7 @@ function openContractRework(){
   });
 
   statusDiv.innerHTML='';
-  allowedStatuses(st.player.age, st.player.overall, st.player.status).forEach(s=>{
+  allowedStatuses(st.player.age, st.player.overall, st.player.status, st.player.pos).forEach(s=>{
     const b=document.createElement('button');
     b.textContent=s;
     b.dataset.value=s;

--- a/js/game.js
+++ b/js/game.js
@@ -1,12 +1,12 @@
-/* WebCareerGame • Pre-Alpha v0.0.9
+/* WebCareerGame • Pre-Alpha v0.1.0
    Game state and persistence helpers.
 */
 
 // Version string injected into the UI and document title.
-const APP_VERSION = 'v0.0.9';
+const APP_VERSION = 'v0.1.0';
 
 // ===== Storage / Globals =====
-const LS_KEY = 'webcareergame.save.v009';
+const LS_KEY = 'webcareergame.save.v010';
 
 // Base strength levels for each club (0-100 scale roughly reflecting squad quality)
 const TEAM_BASE_LEVELS = {

--- a/js/goalkeeper.js
+++ b/js/goalkeeper.js
@@ -1,0 +1,86 @@
+/* Goalkeeper specific logic and minigames */
+
+// Contract tiers for reference in UI or future logic
+const GK_CONTRACT_LEVELS = [
+  {level:'Backup keeper', wage:'\u00a31k–5k/w', contract:'1–2 years', value:'\u00a30.1M–2M'},
+  {level:'Reserve keeper', wage:'\u00a310k–25k/w', contract:'2–3 years', value:'\u00a32M–10M'},
+  {level:'First-choice', wage:'\u00a340k–80k/w', contract:'3–4 years', value:'\u00a310M–40M'},
+  {level:'World-class', wage:'\u00a3100k–250k+/w', contract:'5–6 years', value:'\u00a350M–80M+'},
+];
+
+// ===== Goalkeeper training minigame =====
+function goalkeeperTrainingView(onDone){
+  const box=document.createElement('div'); box.className='glass';
+  box.innerHTML='<div class="h">Goalkeeper drill</div>';
+  const field=document.createElement('div'); field.className='minigame'; box.append(field);
+
+  let correct=0, round=0; const rounds=5; const timers=[];
+
+  function guessPhase(){
+    field.className='minigame gk-guess';
+    field.innerHTML='';
+    const target=Math.random()<0.5?'left':'right';
+    const left=document.createElement('button'); left.textContent='\u2B05\uFE0F';
+    const right=document.createElement('button'); right.textContent='\u27A1\uFE0F';
+    field.append(left,right);
+    let picked=false;
+    function choose(side){
+      if(picked) return; picked=true;
+      if(side===target) correct++;
+      round++;
+      timers.push(setTimeout(()=>{ round<rounds?guessPhase():pushPhase(); },300));
+    }
+    left.onclick=()=>choose('left');
+    right.onclick=()=>choose('right');
+    timers.push(setTimeout(()=>choose('none'),5000));
+  }
+
+  function pushPhase(){
+    field.className='minigame';
+    field.innerHTML='';
+    let clicks=0;
+    const clicker=()=>{ clicks++; };
+    field.onclick=clicker;
+    timers.push(setTimeout(()=>{
+      field.onclick=null;
+      const score=(correct/rounds*0.5)+(Math.min(clicks,50)/50)*0.5;
+      onDone({guesses:correct, clicks, success:clicks>0, score});
+    },5000));
+  }
+
+  guessPhase();
+  return {el:box, cancel:()=>{ timers.forEach(t=>clearTimeout(t)); field.onclick=null; }};
+}
+
+// ===== Goalkeeper match minigame =====
+function goalkeeperMatchMinigameView(title,onDone){
+  const box=document.createElement('div'); box.className='glass';
+  box.innerHTML=`<div class="h">Moment</div><div style="margin-bottom:8px">${title}</div>`;
+  const field=document.createElement('div'); field.className='minigame'; box.append(field);
+
+  let total=10, success=0, current=0; const timers=[];
+
+  function spawn(){
+    if(current>=total){ finish(); return; }
+    current++;
+    const b=document.createElement('div'); b.className='bubble'; b.textContent=current;
+    placeBubble(b, field); field.append(b);
+    const time=Math.max(300,1000-current*60);
+    const timer=setTimeout(()=>{ b.remove(); spawn(); }, time);
+    timers.push(timer);
+    b.onclick=()=>{ success++; clearTimeout(timer); spawnNext(); };
+    function spawnNext(){ b.remove(); spawn(); }
+  }
+
+  function finish(){
+    const score=success/total;
+    const note=document.createElement('div'); note.className='glass'; note.style.marginTop='10px';
+    note.innerHTML=`<div class="h">Result</div><div>Saved ${success}/${total}</div>`;
+    box.append(note);
+    timers.push(setTimeout(()=>onDone({clicks:success,success:success===total,score}),500));
+  }
+
+  spawn();
+  return {el:box, cancel:()=>{ timers.forEach(t=>clearTimeout(t)); field.innerHTML=''; }};
+}
+

--- a/js/market.js
+++ b/js/market.js
@@ -24,12 +24,23 @@ function rollMarketOffers(p){
 function makeOfferFor(player, club){ return makeOfferForVaried(player, club); }
 function makeOfferForVaried(player, club, level){
   const o=player.overall;
-  const status = o>=88?pick(['important','star player'])
-              : o>=80?pick(['key player','important'])
-              : o>=72?'key player'
-              : o>=65?'decent':'rookie';
-  const timeMap={'rookie':'second bench','decent':pick(['bench','rotater']),'key player':pick(['rotater','match player']),'important':pick(['match player','match starter']),'star player':'match starter'};
-  const timeBand=timeMap[status];
+  let status,timeBand;
+  if(player.pos==='Goalkeeper'){
+    status = o>=88?'World-class'
+            : o>=80?'First-choice'
+            : o>=72?'Reserve keeper'
+            : 'Backup keeper';
+    const timeMap={'Backup keeper':'second bench','Reserve keeper':pick(['bench','rotater']),
+      'First-choice':pick(['match player','match starter']),'World-class':'match starter'};
+    timeBand=timeMap[status];
+  } else {
+    status = o>=88?pick(['important','star player'])
+            : o>=80?pick(['key player','important'])
+            : o>=72?'key player'
+            : o>=65?'decent':'rookie';
+    const timeMap={'rookie':'second bench','decent':pick(['bench','rotater']),'key player':pick(['rotater','match player']),'important':pick(['match player','match starter']),'star player':'match starter'};
+    timeBand=timeMap[status];
+  }
   const clubFactor = 0.8 + Math.random()*0.6; // 0.8..1.4
   const posBonus = player.pos==='Attacker'?1.15: player.pos==='Midfield'?1.05: 1.0;
   const years=Math.min(5, Math.max(1, Math.round(randNorm(2.2,1.2))));

--- a/js/match.js
+++ b/js/match.js
@@ -49,8 +49,10 @@ function openMatch(entry){
   const phase=q('#match-phase');
 
   const startMini=(minutesPlanned)=>countdown(phase, ()=>requestAnimationFrame(()=>{
-    const mini=minigameView('Make an impact in this moment!', res=>finishMatch(entry, minutesPlanned, res));
-    phase.append(mini.el);
+    const view = st.player.pos==='Goalkeeper'
+      ? goalkeeperMatchMinigameView('Keep the sheet clean!', res=>finishMatch(entry, minutesPlanned, res))
+      : minigameView('Make an impact in this moment!', res=>finishMatch(entry, minutesPlanned, res));
+    phase.append(view.el);
   }));
   if(youStart){ startMini(90); }
   else if(willSubIn){
@@ -75,7 +77,7 @@ function openTraining(){
   const daysSince = st.lastTrainingDate ? (st.currentDate - st.lastTrainingDate)/(24*3600*1000) : Infinity;
   if(todayEntry && todayEntry.isMatch){ showPopup('Training', 'Match scheduled today. Focus on the game.'); return; }
   if(injured){ showPopup('Training', 'You are injured and cannot train.'); return; }
-  if(daysSince < 2){
+  if(daysSince < 2 && st.player.pos!=='Goalkeeper'){
     const rest = Math.ceil(2-daysSince);
     const msg=`Tried to train but need to rest ${rest} day${rest>1?'s':''} before training again.`;
     Game.log(msg);
@@ -93,11 +95,17 @@ function openTraining(){
   trainingSession={cancelled:false};
   const cancelCd=countdown(phase, ()=>{
     if(trainingSession?.cancelled) return;
-    const mini=minigameView('Finish the drill to improve!', res=>{
-      if(trainingSession?.cancelled) return;
-      finishTraining(res);
-      trainingSession=null;
-    });
+    const mini = st.player.pos==='Goalkeeper'
+      ? goalkeeperTrainingView(res=>{
+          if(trainingSession?.cancelled) return;
+          finishTraining(res);
+          trainingSession=null;
+        })
+      : minigameView('Finish the drill to improve!', res=>{
+          if(trainingSession?.cancelled) return;
+          finishTraining(res);
+          trainingSession=null;
+        });
     phase.append(mini.el);
     trainingSession.miniCancel=mini.cancel;
   });
@@ -161,8 +169,8 @@ function finishMatch(entry, minutes, mini){
   const st=Game.state; const hasMinutes=minutes>0; let rating=null;
   if(hasMinutes){ rating=randNorm(6.4,.6); if(minutes>=60) rating+=.3; rating+=(mini.score||0)*2.0; rating=Math.max(5.0, Math.min(9.8, +rating.toFixed(1))); }
   let goals=0,assists=0; if(hasMinutes){
-    const baseG=st.player.pos==='Attacker'?0.22: st.player.pos==='Midfield'?0.10: 0.06;
-    const baseA=st.player.pos==='Attacker'?0.10: st.player.pos==='Midfield'?0.18: 0.08;
+    const baseG=st.player.pos==='Attacker'?0.22: st.player.pos==='Midfield'?0.10: st.player.pos==='Defender'?0.06:0.01;
+    const baseA=st.player.pos==='Attacker'?0.10: st.player.pos==='Midfield'?0.18: st.player.pos==='Defender'?0.08:0.02;
     const perfBoost=Math.max(0,(rating-6.5)*0.15);
     goals = Math.random()<baseG+perfBoost ? (Math.random()<0.12?2:1) : 0;
     assists = Math.random()<baseA+perfBoost ? 1 : 0;
@@ -222,8 +230,8 @@ function simulateMatch(entry){
   const hasMinutes=minutes>0; let rating=null;
   if(hasMinutes){ rating=randNorm(6.4,.6); if(minutes>=60) rating+=.3; rating+=(mini.score||0)*2.0; rating=Math.max(5.0, Math.min(9.8, +rating.toFixed(1))); }
   let goals=0,assists=0; if(hasMinutes){
-    const baseG=st.player.pos==='Attacker'?0.22: st.player.pos==='Midfield'?0.10: 0.06;
-    const baseA=st.player.pos==='Attacker'?0.10: st.player.pos==='Midfield'?0.18: 0.08;
+    const baseG=st.player.pos==='Attacker'?0.22: st.player.pos==='Midfield'?0.10: st.player.pos==='Defender'?0.06:0.01;
+    const baseA=st.player.pos==='Attacker'?0.10: st.player.pos==='Midfield'?0.18: st.player.pos==='Defender'?0.08:0.02;
     const perfBoost=Math.max(0,(rating-6.5)*0.15);
     goals = Math.random()<baseG+perfBoost ? (Math.random()<0.12?2:1) : 0;
     assists = Math.random()<baseA+perfBoost ? 1 : 0;

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,4 +1,4 @@
-/* WebCareerGame • Pre-Alpha v0.0.9
+/* WebCareerGame • Pre-Alpha v0.1.0
    Shared helper functions for simulation and economy.
 */
 
@@ -66,7 +66,10 @@ function computeSalary(age,overall,league,status,timeBand){
   const overSq = overall*overall;
   const coef = 15;
   const leagueFactor = league==='Premier League'?1.5:1;
-  const statusFactor = {'rookie':0.10,'decent':0.18,'key player':0.35,'important':0.60,'star player':1.00}[status]||0.2;
+  const statusFactor = {
+    'rookie':0.10,'decent':0.18,'key player':0.35,'important':0.60,'star player':1.00,
+    'Backup keeper':0.05,'Reserve keeper':0.15,'First-choice':0.40,'World-class':1.00
+  }[status]||0.2;
   const timeFactor = {'second bench':0.30,'bench':0.50,'rotater':0.80,'match player':1.00,'match starter':1.20}[timeBand]||0.6;
   const ageFactor = age<=18?0.75: age<=23?0.95: age<=28?1.10: age<=31?1.00: 0.85;
   const weekly = overSq*coef*timeFactor*leagueFactor*statusFactor*ageFactor;

--- a/style.css
+++ b/style.css
@@ -1,4 +1,4 @@
-/* WebCareerGame • Pre-Alpha v0.0.5
+/* WebCareerGame • Pre-Alpha v0.1.0
    External stylesheet (dark, minimalist, iOS‑ish)
    Mobile-first, responsive up to desktop
 */
@@ -86,6 +86,11 @@ body{
   font-size: 12px;
   border: 1px solid var(--border);
   background: #101821;
+}
+
+.badge.new {
+  background: var(--success);
+  color: #000;
 }
 
 
@@ -236,6 +241,10 @@ a{ color:var(--primary) }
 /* Minigame */
 .minigame{position:relative;width:100%;height:260px;border-radius:12px;background:#0e1620;border:1px dashed var(--border);overflow:hidden}
 .bubble{position:absolute;width:34px;height:34px;border-radius:999px;background:linear-gradient(180deg,#2a6df1,#204fb3);display:grid;place-items:center;font-weight:900;user-select:none;cursor:pointer}
+
+.gk-guess{display:flex;height:260px}
+.gk-guess button{flex:1;font-size:24px;border:0;background:#13202d;color:var(--text);cursor:pointer}
+.gk-guess button:hover{background:#173347}
 
 .shop-item{display:flex;justify-content:space-between;align-items:flex-start;gap:12px}
 .shop-item .desc{font-size:12px;margin-top:4px}


### PR DESCRIPTION
## Summary
- add goalkeeper contracts, training and match minigames
- bump version to v0.1.0 with landing page log entry
- enable goalkeeper selection and highlight as new

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7290ed9d0832dab4f3b9020194d1d