### PR TITLE
feat: enhance goalkeeper training UX

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -118,7 +118,8 @@ function renderAll(){
   if(trainBtn){
     const hasMatch=todayEntry && todayEntry.isMatch;
     const injured=st.player.status && st.player.status.toLowerCase().includes('injur');
-    const cooldown=st.lastTrainingDate ? (st.currentDate - st.lastTrainingDate)/(24*3600*1000) < 2 : false;
+    const diff=st.lastTrainingDate ? (st.currentDate - st.lastTrainingDate)/(24*3600*1000) : Infinity;
+    const cooldown = st.player.pos==='Goalkeeper' ? diff < 1 : diff < 2;
     trainBtn.disabled = hasMatch || injured || cooldown;
   }
 


### PR DESCRIPTION
## Summary
- require a daily cooldown for goalkeeper training with a popup when already trained
- show instructions and a Ready button before goalkeeper training starts
- display overall gain popup after any training session

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a733c356a8832da90407887feddbbd