### PR TITLE
Refine goalkeeper training flow and add training warning

### DIFF
--- a/js/goalkeeper.js
+++ b/js/goalkeeper.js
@@ -30,24 +30,26 @@ function goalkeeperTrainingView(onDone){
       if(side===target) correct++;
       ball.style.left = target==='left' ? '20%' : '80%';
       round++;
-      timers.push(setTimeout(()=>{ round<rounds?guessPhase():pushPhase(); },500));
+      if(round<rounds){
+        timers.push(setTimeout(guessPhase,500));
+      } else {
+        finish();
+      }
     }
     left.onclick=()=>choose('left');
     right.onclick=()=>choose('right');
     timers.push(setTimeout(()=>choose('none'),5000));
   }
 
-  function pushPhase(){
+  function finish(){
     field.className='minigame';
     field.innerHTML='';
-    let clicks=0;
-    const clicker=()=>{ clicks++; };
-    field.onclick=clicker;
-    timers.push(setTimeout(()=>{
-      field.onclick=null;
-      const score=(correct/rounds*0.5)+(Math.min(clicks,50)/50)*0.5;
-      onDone({guesses:correct, clicks, success:clicks>0, score});
-    },5000));
+    const score=correct/rounds;
+    const rating= correct===5 ? 'excellent' : correct>=4 ? 'good' : correct>=2 ? 'ok' : 'bad';
+    const note=document.createElement('div'); note.className='glass';
+    note.innerHTML=`<div class="h">Result</div><div>Guessed ${correct}/${rounds}. ${rating}.</div>`;
+    field.append(note);
+    timers.push(setTimeout(()=>onDone({guesses:correct, clicks:0, success:correct>=3, score}),500));
   }
 
   guessPhase();

--- a/js/match.js
+++ b/js/match.js
@@ -77,11 +77,11 @@ function openTraining(){
   const daysSince = st.lastTrainingDate ? (st.currentDate - st.lastTrainingDate)/(24*3600*1000) : Infinity;
   if(todayEntry && todayEntry.isMatch){ showPopup('Training', 'Match scheduled today. Focus on the game.'); return; }
   if(injured){ showPopup('Training', 'You are injured and cannot train.'); return; }
-  if(st.player.pos==='Goalkeeper' && daysSince < 1){
+  if(daysSince < 1){
     Game.log('Tried to train twice today. Come back tomorrow.');
     Game.save();
     renderAll();
-    showPopup('Training', 'Trained today. Come back tomorrow.');
+    showPopup('Training', 'You have trained today, come back tomorrow.');
     return;
   }
   if(daysSince < 2 && st.player.pos!=='Goalkeeper'){


### PR DESCRIPTION
## Summary
- End goalkeeper training immediately after five rounds and display a rating (bad/ok/good/excellent)
- Show warning popup when trying to train more than once in a day

## Testing
- `node -c js/goalkeeper.js`
- `node -c js/match.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a74f37a644832da171252bce2c50ad