### PR TITLE
Show warning when training twice in a day

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -78,6 +78,7 @@ function openTraining(){
   if(todayEntry && todayEntry.isMatch){ showPopup('Training', 'Match scheduled today. Focus on the game.'); return; }
   if(injured){ showPopup('Training', 'You are injured and cannot train.'); return; }
   if(daysSince < 1){
+    console.log('Tried to train twice today. Come back tomorrow.');
     Game.log('Tried to train twice today. Come back tomorrow.');
     Game.save();
     renderAll();

--- a/js/ui.js
+++ b/js/ui.js
@@ -116,11 +116,7 @@ function renderAll(){
 
   const trainBtn=q('#btn-train');
   if(trainBtn){
-    const hasMatch=todayEntry && todayEntry.isMatch;
-    const injured=st.player.status && st.player.status.toLowerCase().includes('injur');
-    const diff=st.lastTrainingDate ? (st.currentDate - st.lastTrainingDate)/(24*3600*1000) : Infinity;
-    const cooldown = st.player.pos==='Goalkeeper' ? diff < 1 : diff < 2;
-    trainBtn.disabled = hasMatch || injured || cooldown;
+    trainBtn.disabled=false;
   }
 
   const nextBtn=q('#btn-next');


### PR DESCRIPTION
## Summary
- Always enable the training button so UI can warn about training restrictions
- Warn and log when a player tries to train twice in a single day

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a75097ac74832dbde98983fef5c2f3