### PR TITLE
Improve realism of match scheduling

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -115,7 +115,7 @@ const Game = {
     this.state.leagueSnapshotWeek = 0;
     this.state.seasonSummary = null;
     const year = new Date().getFullYear();
-    const first = randomWedToSatOfWeek(lastSaturdayOfAugust(year));
+    const first = realisticMatchDate(lastSaturdayOfAugust(year));
     this.state.schedule = buildSchedule(first, 38);
     // start at season start marker day for clarity
     this.state.currentDate = this.state.schedule[0].date;

--- a/js/season.js
+++ b/js/season.js
@@ -184,7 +184,7 @@ function openSeasonEnd(){
     st.season += 1; st.week = 1;
     st.player.age += 1;
     const baseYear = new Date(new Date(st.schedule[0].date).getFullYear()+1,7,31).getFullYear();
-    const first = randomWedToSatOfWeek(lastSaturdayOfAugust(baseYear));
+    const first = realisticMatchDate(lastSaturdayOfAugust(baseYear));
     st.schedule = buildSchedule(first, 38, st.player.club);
     st.currentDate = st.schedule[0].date; // on season start marker
     st.seasonMinutes=0; st.seasonGoals=0; st.seasonAssists=0; st.seasonCleanSheets=0;

--- a/js/utils.js
+++ b/js/utils.js
@@ -8,11 +8,16 @@ function getTeamLevel(club){
 
 // ===== Date / Schedule helpers =====
 function lastSaturdayOfAugust(year){ const d = new Date(year,7,31); while(d.getDay()!==6) d.setDate(d.getDate()-1); return d; }
-function randomWedToSatOfWeek(anchor){ // returns a date between Wed..Sat of the week of anchor
+function realisticMatchDate(anchor){ // returns a plausible Premier League matchday for the week of anchor
   const base=new Date(anchor.getTime());
   // shift to Monday of that week
   base.setDate(base.getDate() - ((base.getDay()+6)%7));
-  const offset = [3,4,5,6][Math.floor(Math.random()*4)]; // Wed..Sat
+  const roll=Math.random();
+  let offset;
+  if(roll<0.75) offset=5;         // Saturday
+  else if(roll<0.95) offset=6;    // Sunday
+  else if(roll<0.98) offset=4;    // Friday night
+  else offset=7;                  // Monday night
   const d = new Date(base.getTime()); d.setDate(base.getDate()+offset); return d;
 }
 function weekAfter(d){ const n=new Date(d.getTime()); n.setDate(n.getDate()+7); return n; }
@@ -26,7 +31,7 @@ function buildSchedule(firstMatchDate, weeks, excludeClub){
   let last = new Date(firstMatchDate.getTime());
   let current = firstMatchDate;
   for(let i=0;i<weeks;i++){
-    const d = randomWedToSatOfWeek(current);
+    const d = realisticMatchDate(current);
     if(d.getTime() <= last.getTime()) d.setDate(last.getDate()+2); // ensure increasing
     last = d;
     out.push({date:d.getTime(), opponent:opponents[i%opponents.length], isMatch:true, played:false, result:null, scoreline:null, type:'match', competition:'League'});


### PR DESCRIPTION
## Summary
- Adjust match date generator to primarily schedule weekend fixtures with occasional Friday and Monday matches, better mirroring Premier League timing.
- Update season and game initialization to use the new realistic matchdate helper.

## Testing
- `node --check js/utils.js js/game.js js/season.js`
- `npm test` *(fails: no `package.json` present)*

------
https://chatgpt.com/codex/tasks/task_e_68a758c4e854832d8ec777bea9e1c6ee