### PR TITLE
feat: add EFL Championship league

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -20,16 +20,41 @@ const TEAM_BASE_LEVELS = {
   'Crystal Palace': 72,
   'Everton': 72,
   'Fulham': 73,
-  'Leeds United': 74,
   'Liverpool': 88,
   'Man City': 90,
   'Man Utd': 84,
   'Newcastle': 80,
   'Nottm Forest': 70,
-  'Sunderland': 69,
+  'Sheffield Utd': 70,
   'Tottenham': 80,
   'West Ham': 75,
-  'Wolves': 71
+  'Wolves': 71,
+  'Luton Town': 68,
+  // EFL Championship
+  'Birmingham City': 65,
+  'Blackburn Rovers': 68,
+  'Bristol City': 66,
+  'Cardiff City': 66,
+  'Coventry City': 72,
+  'Huddersfield Town': 64,
+  'Hull City': 67,
+  'Ipswich Town': 65,
+  'Leeds United': 74,
+  'Leicester City': 82,
+  'Middlesbrough': 72,
+  'Millwall': 67,
+  'Norwich City': 72,
+  'Plymouth Argyle': 63,
+  'Preston North End': 67,
+  'Queens Park Rangers': 63,
+  'Rotherham United': 60,
+  'Sheffield Wednesday': 64,
+  'Southampton': 80,
+  'Stoke City': 68,
+  'Sunderland': 69,
+  'Swansea City': 67,
+  'Watford': 70,
+  'West Brom': 71
 };
 
 const Game = {
@@ -116,7 +141,7 @@ const Game = {
     this.state.seasonSummary = null;
     const year = new Date().getFullYear();
     const first = realisticMatchDate(lastSaturdayOfAugust(year));
-    this.state.schedule = buildSchedule(first, 38);
+    this.state.schedule = buildSchedule(first, 38, null, 'Premier League');
     // start at season start marker day for clarity
     this.state.currentDate = this.state.schedule[0].date;
     this.log(`Career started: ${this.state.player.name}, ${this.state.player.age}, ${this.state.player.pos}, ${this.state.player.origin}`);

--- a/js/season.js
+++ b/js/season.js
@@ -7,7 +7,7 @@ function updateLeagueSnapshot(){
   const played = st.schedule.filter(e=>e.isMatch && e.played).length;
   if(st.leagueSnapshotWeek===played) return;
   const club=st.player.club;
-  const teams=makeOpponents().map(t=>({team:t}));
+  const teams=makeOpponents(st.player.league||'Premier League').map(t=>({team:t}));
   const stats={w:0,d:0,l:0,gf:0,ga:0};
   st.schedule.filter(e=>e.isMatch && e.played).forEach(e=>{
     if(e.result==='W') stats.w++;
@@ -54,7 +54,7 @@ function openSeasonEnd(){
     stats.pts=stats.w*3+stats.d;
 
     const club=st.player.club;
-    const teams=makeOpponents().map(t=>({team:t}));
+    const teams=makeOpponents(st.player.league||'Premier League').map(t=>({team:t}));
     if(!teams.find(t=>t.team===club)){ teams.pop(); teams.push({team:club}); }
     teams.forEach(t=>{
       if(t.team===club){ Object.assign(t,stats); }
@@ -171,10 +171,10 @@ function openSeasonEnd(){
         ? lastSeason.min>900 && lastSeason.cleanSheets<4
         : lastSeason.min>900 && (lastSeason.goals+lastSeason.assists)<2;
       if(poorSeason && Math.random()<0.5){
-        const lower=makeOpponents().filter(t=>getTeamLevel(t)<getTeamLevel(st.player.club));
+        const lower=makeOpponents(st.player.league||'Premier League').filter(t=>getTeamLevel(t)<getTeamLevel(st.player.club));
         if(lower.length){
           const club=pick(lower);
-          st.lastOffers=[makeOfferForVaried(st.player,club,getTeamLevel(club))];
+          st.lastOffers=[makeOfferForVaried(st.player,club,getTeamLevel(club),CLUB_TO_LEAGUE[club])];
           st.player.transferListed=true;
           Game.log('Club considers selling you after poor season.');
         }
@@ -185,7 +185,7 @@ function openSeasonEnd(){
     st.player.age += 1;
     const baseYear = new Date(new Date(st.schedule[0].date).getFullYear()+1,7,31).getFullYear();
     const first = realisticMatchDate(lastSaturdayOfAugust(baseYear));
-    st.schedule = buildSchedule(first, 38, st.player.club);
+    st.schedule = buildSchedule(first, 38, st.player.club, st.player.league||'Premier League');
     st.currentDate = st.schedule[0].date; // on season start marker
     st.seasonMinutes=0; st.seasonGoals=0; st.seasonAssists=0; st.seasonCleanSheets=0;
     Object.keys(st.shopPurchases||{}).forEach(id=>{ const it=SHOP_ITEMS.find(i=>i.id===id); if(it && it.perSeason) delete st.shopPurchases[id]; });

--- a/js/utils.js
+++ b/js/utils.js
@@ -2,6 +2,26 @@
    Shared helper functions for simulation and economy.
 */
 
+// ===== League data =====
+const LEAGUES = {
+  'Premier League': [
+    'Arsenal', 'Aston Villa', 'Bournemouth', 'Brentford', 'Brighton',
+    'Burnley', 'Chelsea', 'Crystal Palace', 'Everton', 'Fulham',
+    'Liverpool', 'Man City', 'Man Utd', 'Newcastle', 'Nottm Forest',
+    'Sheffield Utd', 'Tottenham', 'West Ham', 'Wolves', 'Luton Town'
+  ],
+  'EFL Championship': [
+    'Birmingham City','Blackburn Rovers','Bristol City','Cardiff City','Coventry City',
+    'Huddersfield Town','Hull City','Ipswich Town','Leeds United','Leicester City',
+    'Middlesbrough','Millwall','Norwich City','Plymouth Argyle','Preston North End',
+    'Queens Park Rangers','Rotherham United','Sheffield Wednesday','Southampton',
+    'Stoke City','Sunderland','Swansea City','Watford','West Brom'
+  ]
+};
+const CLUB_TO_LEAGUE = {};
+Object.entries(LEAGUES).forEach(([lg,teams])=>teams.forEach(t=>{CLUB_TO_LEAGUE[t]=lg;}));
+const ALL_CLUBS = Object.entries(LEAGUES).flatMap(([lg,teams])=>teams.map(t=>({club:t,league:lg})));
+
 function getTeamLevel(club){
   return (Game.state.teamLevels && Game.state.teamLevels[club]) || TEAM_BASE_LEVELS[club] || 60;
 }
@@ -22,8 +42,8 @@ function realisticMatchDate(anchor){ // returns a plausible Premier League match
 }
 function weekAfter(d){ const n=new Date(d.getTime()); n.setDate(n.getDate()+7); return n; }
 
-function buildSchedule(firstMatchDate, weeks, excludeClub){
-  const opponents = makeOpponents().filter(t=>t!==excludeClub);
+function buildSchedule(firstMatchDate, weeks, excludeClub, league=Game.state.player?.league||'Premier League'){
+  const opponents = makeOpponents(league).filter(t=>t!==excludeClub);
   const out = [];
   // season start marker one day before first kickoff
   const seasonStart = new Date(firstMatchDate.getTime()); seasonStart.setDate(seasonStart.getDate()-1);
@@ -43,23 +63,17 @@ function buildSchedule(firstMatchDate, weeks, excludeClub){
   return out;
 }
 
-function ensureNoSelfMatches(club){
+function ensureNoSelfMatches(club, league=Game.state.player?.league||'Premier League'){
   if(!club) return;
-  const others = makeOpponents().filter(t=>t!==club);
+  const others = makeOpponents(league).filter(t=>t!==club);
   Game.state.schedule.forEach(e=>{
     if(e.isMatch && e.opponent===club){ e.opponent = pick(others); }
   });
 }
 
 // ===== Data / RNG helpers =====
-function makeOpponents(){
-  // 20 Premier League teams (2023/24 season)
-  return [
-    'Arsenal', 'Aston Villa', 'Bournemouth', 'Brentford', 'Brighton',
-    'Burnley', 'Chelsea', 'Crystal Palace', 'Everton', 'Fulham',
-    'Leeds United', 'Liverpool', 'Man City', 'Man Utd', 'Newcastle',
-    'Nottm Forest', 'Sunderland', 'Tottenham', 'West Ham', 'Wolves'
-  ];
+function makeOpponents(league=Game.state.player?.league||'Premier League'){
+  return LEAGUES[league] || LEAGUES['Premier League'];
 }
 function pick(a){ return a[Math.floor(Math.random()*a.length)]; }
 function randNorm(mu=0, sigma=1){ const u=1-Math.random(); const v=1-Math.random(); return mu+sigma*Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }


### PR DESCRIPTION
## Summary
- add Premier League and new EFL Championship team lists and league mapping
- expand transfer market and schedule generation to use league info
- rebuild schedule when signing and seed team strength for Championship clubs

## Testing
- `node --check js/utils.js js/market.js js/season.js js/game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a76c24d5d0832db5fd6ee4559be0b8