### PR TITLE
Update league rosters for 25/26 and tune second division growth

### DIFF
--- a/js/market.js
+++ b/js/market.js
@@ -7,8 +7,10 @@ function rollMarketOffers(p){
     if(offers.length>=count) break;
     const lvl=getTeamLevel(club);
     const diff=lvl - p.overall;
-    const chance = diff<=0?0.8: diff<5?0.6: diff<10?0.3: 0.05; // big clubs rarely approach weak players
-    if(Math.random()<chance) offers.push(makeOfferForVaried(p,club,lvl,league));
+    let chance = diff<=0?0.8: diff<5?0.6: diff<10?0.3: 0.05; // big clubs rarely approach weak players
+    if(league==='EFL Championship' && (p.overall<75 || p.age<=23)) chance+=0.2;
+    if(lvl>85 && p.overall>=80) chance+=0.1;
+    if(Math.random()<Math.min(chance,0.95)) offers.push(makeOfferForVaried(p,club,lvl,league));
   }
   if(p.releaseClause && p.overall>=75 && Math.random()<0.15){
     const big=ALL_CLUBS.filter(c=>getTeamLevel(c.club)>85 && c.club!==p.club);
@@ -40,6 +42,10 @@ function makeOfferForVaried(player, club, level, league){
             : o>=65?'decent':'rookie';
     const timeMap={'rookie':'second bench','decent':pick(['bench','rotater']),'key player':pick(['rotater','match player']),'important':pick(['match player','match starter']),'star player':'match starter'};
     timeBand=timeMap[status];
+  }
+  if(league==='EFL Championship' && (player.age<=23 || player.overall<75)){
+    const order=['second bench','bench','rotater','match player','match starter'];
+    let idx=order.indexOf(timeBand); if(idx<order.length-1) timeBand=order[idx+1];
   }
   const clubFactor = 0.8 + Math.random()*0.6; // 0.8..1.4
   const posBonus = player.pos==='Attacker'?1.15: player.pos==='Midfield'?1.05: 1.0;

--- a/js/utils.js
+++ b/js/utils.js
@@ -4,18 +4,19 @@
 
 // ===== League data =====
 const LEAGUES = {
+  // 2025/26 season line-ups
   'Premier League': [
     'Arsenal', 'Aston Villa', 'Bournemouth', 'Brentford', 'Brighton',
-    'Burnley', 'Chelsea', 'Crystal Palace', 'Everton', 'Fulham',
-    'Liverpool', 'Man City', 'Man Utd', 'Newcastle', 'Nottm Forest',
-    'Sheffield Utd', 'Tottenham', 'West Ham', 'Wolves', 'Luton Town'
+    'Chelsea', 'Crystal Palace', 'Everton', 'Fulham', 'Ipswich Town',
+    'Leicester City', 'Liverpool', 'Man City', 'Man Utd', 'Newcastle',
+    'Nottm Forest', 'Southampton', 'Tottenham', 'West Ham', 'Wolves'
   ],
   'EFL Championship': [
     'Birmingham City','Blackburn Rovers','Bristol City','Cardiff City','Coventry City',
-    'Huddersfield Town','Hull City','Ipswich Town','Leeds United','Leicester City',
-    'Middlesbrough','Millwall','Norwich City','Plymouth Argyle','Preston North End',
-    'Queens Park Rangers','Rotherham United','Sheffield Wednesday','Southampton',
-    'Stoke City','Sunderland','Swansea City','Watford','West Brom'
+    'Huddersfield Town','Hull City','Leeds United','Middlesbrough','Millwall',
+    'Norwich City','Plymouth Argyle','Preston North End','Queens Park Rangers','Rotherham United',
+    'Sheffield Wednesday','Stoke City','Sunderland','Swansea City','Watford',
+    'West Brom','Burnley','Luton Town','Sheffield Utd'
   ]
 };
 const CLUB_TO_LEAGUE = {};
@@ -84,7 +85,7 @@ function sameDay(a,b){ const da=new Date(a), db=new Date(b); return da.getFullYe
 function computeSalary(age,overall,league,status,timeBand){
   const overSq = overall*overall;
   const coef = 15;
-  const leagueFactor = league==='Premier League'?1.5:1;
+  const leagueFactor = league==='Premier League'?1.5: league==='EFL Championship'?0.9:1;
   const statusFactor = {
     'rookie':0.10,'decent':0.18,'key player':0.35,'important':0.60,'star player':1.00,
     'Backup keeper':0.05,'Reserve keeper':0.15,'First-choice':0.40,'World-class':1.00
@@ -95,7 +96,7 @@ function computeSalary(age,overall,league,status,timeBand){
   return Math.max(500, Math.min(weekly, 600000));
 }
 function computeValue(overall,league,weeklySalary){
-  const leagueFactor=league==='Premier League'?1.15:1;
+  const leagueFactor=league==='Premier League'?1.15: league==='EFL Championship'?0.9:1;
   const base=(overall*overall)*330*leagueFactor;
   const fromSalary=weeklySalary*52*4; // salary-derived valuation proxy
   return Math.max(base, fromSalary);
@@ -119,6 +120,7 @@ function applyPostMatchGrowth(st, minutes, rating, goals, assists, played, conce
   if(minutes<target*.4) delta-=0.15; if(st.player.age>=31) delta-=0.05;
   const clubLvl=getTeamLevel(st.player.club);
   if(clubLvl<75) delta+=0.1; // lower level clubs boost growth
+  if(st.player.league==='EFL Championship' && st.player.age<=23) delta+=0.05;
   delta += played?0.1:-0.05;
   st.player.overall = Math.max(55, Math.min(100, +(st.player.overall+delta).toFixed(2)));
 }


### PR DESCRIPTION
## Summary
- refresh Premier League and Championship team lists for the 2025/26 season
- lower Championship wages and boost growth for young players
- bias transfer offers so lower league clubs target youth while elites pursue high overalls

## Testing
- `node -c js/utils.js`
- `node -c js/market.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7797bce24832d886d1b7298fbc58c