### PR TITLE
Add loan system for young players

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -60,7 +60,7 @@ const TEAM_BASE_LEVELS = {
 const Game = {
   state: {
     // player fields get filled on newGame
-    player: null, // {name, age, origin, pos, overall, club, league, status, timeBand, salary, value, balance, yearsLeft, transferListed, alwaysPlay, goldenClub, releaseClause, marketBlocked, contractReworkYear}
+    player: null, // {name, age, origin, pos, overall, club, league, status, timeBand, salary, value, balance, yearsLeft, transferListed, alwaysPlay, goldenClub, releaseClause, marketBlocked, contractReworkYear, loan}
     season: 1,
     week: 1,
     currentDate: null,
@@ -126,6 +126,7 @@ const Game = {
       releaseClause: 0,
       marketBlocked: 0,
       contractReworkYear: 0,
+      loan: null,
     };
     this.state.season = 1; this.state.week = 1;
     this.state.minutesPlayed = 0; this.state.goals = 0; this.state.assists = 0; this.state.cleanSheets = 0;
@@ -172,6 +173,7 @@ function migrateState(st){
     st.player.releaseClause = st.player.releaseClause || 0;
     st.player.marketBlocked = st.player.marketBlocked || 0;
     st.player.contractReworkYear = st.player.contractReworkYear || 0;
+    st.player.loan = st.player.loan || null;
   }
   if(typeof st.currentDate !== 'number'){
     const firstSched = Array.isArray(st.schedule) && st.schedule.length ? st.schedule[0] : null;

--- a/js/market.js
+++ b/js/market.js
@@ -116,12 +116,28 @@ function acceptOffer(i){
   st.player.releaseClause=Math.round((o.releaseClauseFee?o.releaseClauseFee:o.value)*1.5);
   st.player.marketBlocked=0; st.player.contractReworkYear=0;
   if(o.releaseClauseFee) Game.log(`Release clause of ${Game.money(o.releaseClauseFee)} activated by ${o.club}`);
+
+  // Check if player should be loaned to a lower league
+  const clubLevel=getTeamLevel(o.club);
+  const needsLoan = clubLevel>85 && st.player.overall+10<clubLevel;
+  if(needsLoan){
+    const loanClub = pick(LEAGUES['EFL Championship']);
+    const loanYears = randInt(1,2);
+    st.player.loan = {parentClub:o.club, parentLeague:o.league, seasonsLeft:loanYears};
+    st.player.club = loanClub;
+    st.player.league = 'EFL Championship';
+    Game.log(`${o.club} loaned you to ${loanClub} for ${loanYears} season${loanYears>1?'s':''}`);
+    showPopup('Loan move', `${o.club} loaned you to ${loanClub} for ${loanYears} season${loanYears>1?'s':''}.`);
+  } else {
+    st.player.loan = null;
+  }
+
   const year=new Date().getFullYear();
   const first=realisticMatchDate(lastSaturdayOfAugust(year));
-  st.schedule=buildSchedule(first,38,o.club,o.league);
+  st.schedule=buildSchedule(first,38,st.player.club,st.player.league);
   st.currentDate=st.schedule[0].date;
   st.week=1;
-  Game.log(`Signed for ${o.club}, ${o.years}y, ${o.status}, ${o.timeBand}, ${Game.money(o.salary)}/w`);
+  Game.log(`Signed for ${o.club}${st.player.loan?` (loaned to ${st.player.club})`:''}, ${o.years}y, ${o.status}, ${o.timeBand}, ${Game.money(o.salary)}/w`);
   Game.save(); renderAll(); q('#market-modal').removeAttribute('open');
 }
 

--- a/js/season.js
+++ b/js/season.js
@@ -183,6 +183,16 @@ function openSeasonEnd(){
 
     st.season += 1; st.week = 1;
     st.player.age += 1;
+    if(st.player.loan){
+      st.player.loan.seasonsLeft -= 1;
+      if(st.player.loan.seasonsLeft<=0){
+        st.player.club = st.player.loan.parentClub;
+        st.player.league = st.player.loan.parentLeague;
+        Game.log(`Loan ended. Returned to ${st.player.club}.`);
+        showPopup('Loan ended', `Returned to ${st.player.club}.`);
+        st.player.loan = null;
+      }
+    }
     const baseYear = new Date(new Date(st.schedule[0].date).getFullYear()+1,7,31).getFullYear();
     const first = realisticMatchDate(lastSaturdayOfAugust(baseYear));
     st.schedule = buildSchedule(first, 38, st.player.club, st.player.league||'Premier League');


### PR DESCRIPTION
## Summary
- track loan status in player state with migration support
- auto-loan low-rated signings from elite clubs to EFL Championship teams
- return players to parent club when loan expires at season start

## Testing
- `node --check js/game.js`
- `node --check js/market.js`
- `node --check js/season.js`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a77fba6bc8832da18b2dc7bb0f81ae