### PR TITLE
Improve narrow phone responsiveness

### DIFF
--- a/style.css
+++ b/style.css
@@ -283,6 +283,16 @@ a{ color:var(--primary) }
   .card{padding:12px}
   .btn{padding:8px 12px;font-size:14px}
 }
+/* Extra small screen tweaks */
+@media(max-width:480px){
+  .calendar{grid-template-columns:repeat(3, minmax(0, 1fr))}
+  .day{height:100px;padding:6px}
+  .brand{flex-wrap:wrap}
+  .brand h1{font-size:16px}
+  .version{font-size:12px}
+  .btn{padding:6px 10px;font-size:13px}
+}
+
 
 /* Contract modal */
 .option{cursor:pointer}


### PR DESCRIPTION
## Summary
- Adjust calendar grid and element sizing for very small screens
- Tune header and button styles for narrow phones

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9e62cc96c832d8c74183931409b1f