### PR TITLE
Improve mobile compatibility by dropping unsupported JS features

### DIFF
--- a/js/contract.js
+++ b/js/contract.js
@@ -2,7 +2,7 @@
 function statusRank(s){
   const map={'rookie':0,'decent':1,'key player':2,'important':3,'star player':4,
     'Backup keeper':0,'Reserve keeper':1,'First-choice':2,'World-class':3};
-  return map[s]??0;
+  return Object.prototype.hasOwnProperty.call(map, s) ? map[s] : 0;
 }
 function timeRank(t){ return ['second bench','bench','rotater','match player','match starter'].indexOf(t); }
 function allowedStatuses(age,overall,current,pos){

--- a/js/main.js
+++ b/js/main.js
@@ -25,7 +25,8 @@ function wireEvents(){
       const name=q('#name').value||'Player';
       const age=q('#age').value||16;
       const origin=q('#origin').value;
-      const pos=[...document.querySelectorAll('input[name=pos]')].find(x=>x.checked)?.value||'Attacker';
+      const posEl=[...document.querySelectorAll('input[name=pos]')].find(x=>x.checked);
+      const pos=posEl ? posEl.value : 'Attacker';
       const alwaysPlay=q('#always-play').checked;
       Game.newGame({name,age,origin,pos,alwaysPlay});
       renderAll();

--- a/js/match.js
+++ b/js/match.js
@@ -102,15 +102,15 @@ function openTraining(){
   q('#training-modal').setAttribute('open','');
   trainingSession={cancelled:false};
   const startMini=()=>{
-    if(trainingSession?.cancelled) return;
+    if(trainingSession && trainingSession.cancelled) return;
     const mini = st.player.pos==='Goalkeeper'
       ? goalkeeperTrainingView(res=>{
-          if(trainingSession?.cancelled) return;
+          if(trainingSession && trainingSession.cancelled) return;
           finishTraining(res);
           trainingSession=null;
         })
       : minigameView('Finish the drill to improve!', res=>{
-          if(trainingSession?.cancelled) return;
+          if(trainingSession && trainingSession.cancelled) return;
           finishTraining(res);
           trainingSession=null;
         });
@@ -229,7 +229,7 @@ function finishMatch(entry, minutes, mini){
   const c=q('#match-content'); const box=document.createElement('div'); box.className='glass';
   const stats=[
     `<div class="kv"><div class="k">Minutes</div><div class="v">${minutes}</div></div>`,
-    `<div class="kv"><div class="k">Rating</div><div class="v">${rating?.toFixed?rating.toFixed(1):rating}</div></div>`,
+    `<div class="kv"><div class="k">Rating</div><div class="v">${rating && rating.toFixed ? rating.toFixed(1) : rating}</div></div>`,
   ];
   if(rating!=='DNP'){
     if(st.player.pos==='Goalkeeper'){

--- a/js/utils.js
+++ b/js/utils.js
@@ -44,8 +44,9 @@ function realisticMatchDate(anchor){ // returns a plausible Premier League match
 }
 function weekAfter(d){ const n=new Date(d.getTime()); n.setDate(n.getDate()+7); return n; }
 
-function buildSchedule(firstMatchDate, weeks, excludeClub, league=Game.state.player?.league||'Premier League'){
-  const opponents = makeOpponents(league).filter(t=>t!==excludeClub);
+function buildSchedule(firstMatchDate, weeks, excludeClub, league){
+  const lg = league || (Game.state.player && Game.state.player.league) || 'Premier League';
+  const opponents = makeOpponents(lg).filter(t=>t!==excludeClub);
   const out = [];
   // season start marker one day before first kickoff
   const seasonStart = new Date(firstMatchDate.getTime()); seasonStart.setDate(seasonStart.getDate()-1);
@@ -65,17 +66,19 @@ function buildSchedule(firstMatchDate, weeks, excludeClub, league=Game.state.pla
   return out;
 }
 
-function ensureNoSelfMatches(club, league=Game.state.player?.league||'Premier League'){
+function ensureNoSelfMatches(club, league){
+  const lg = league || (Game.state.player && Game.state.player.league) || 'Premier League';
   if(!club) return;
-  const others = makeOpponents(league).filter(t=>t!==club);
+  const others = makeOpponents(lg).filter(t=>t!==club);
   Game.state.schedule.forEach(e=>{
     if(e.isMatch && e.opponent===club){ e.opponent = pick(others); }
   });
 }
 
 // ===== Data / RNG helpers =====
-function makeOpponents(league=Game.state.player?.league||'Premier League'){
-  return LEAGUES[league] || LEAGUES['Premier League'];
+function makeOpponents(league){
+  const lg = league || (Game.state.player && Game.state.player.league) || 'Premier League';
+  return LEAGUES[lg] || LEAGUES['Premier League'];
 }
 function pick(a){ return a[Math.floor(Math.random()*a.length)]; }
 function randNorm(mu=0, sigma=1){ const u=1-Math.random(); const v=1-Math.random(); return mu+sigma*Math.sqrt(-2*Math.log(u))*Math.cos(2*Math.PI*v); }


### PR DESCRIPTION
## Summary
- Avoid optional chaining when reading position in the start form
- Remove optional chaining in scheduling helpers
- Guard training and rating logic without optional chaining
- Replace nullish coalescing in contract ranking

## Testing
- `node --check js/main.js`
- `node --check js/utils.js`
- `node --check js/match.js`
- `node --check js/contract.js`


------
https://chatgpt.com/codex/tasks/task_e_68a9e7f30048832db3020a3c0e54ef83