### PR TITLE
Fix mobile career start and add error log modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,7 +40,10 @@
               <div class="h">Current version</div>
               <div class="row pills"><span class="pill"><span class="app-version"></span></span><span class="pill">pre-alpha</span><span class="pill">auto-advance + season</span></div>
             </div>
-            <button class="btn ghost" id="btn-reset" title="Clear local save">Reset save</button>
+            <div class="row">
+              <button class="btn ghost" id="btn-reset" title="Clear local save">Reset save</button>
+              <button class="btn ghost" id="btn-alert-log" title="Show alert log">Log</button>
+            </div>
           </div>
         </div>
 
@@ -287,6 +290,19 @@
       </header>
       <div class="content" id="message-content"></div>
       <div class="content sheet-actions" id="message-actions"></div>
+    </div>
+  </dialog>
+
+  <!-- Alert log modal -->
+  <dialog id="alert-log-modal" class="modal">
+    <div class="sheet">
+      <header class="brand sheet-head">
+        <div class="logo"></div><h1 class="sheet-title">Alert log</h1>
+        <button class="btn ghost" id="close-alert-log">Close</button>
+      </header>
+      <div class="content">
+        <div id="alert-log" class="live-log"></div>
+      </div>
     </div>
   </dialog>
 </body>

--- a/js/game.js
+++ b/js/game.js
@@ -8,7 +8,7 @@ const APP_VERSION = 'v0.1.0';
 // ===== Storage / Globals =====
 const LS_KEY = 'webcareergame.save.v010';
 
-const TEAM_BASE_LEVELS_25_26 = {
+const TEAM_BASE_LEVELS = {
   // Premier League
   'Liverpool': 90,       // Defending champions, major summer spending :contentReference[oaicite:2]{index=2}
   'Arsenal': 89,        // Significant squad upgrades—depth across all positions :contentReference[oaicite:3]{index=3}

--- a/js/main.js
+++ b/js/main.js
@@ -1,3 +1,24 @@
+// ===== Alert Log =====
+const alertLog=[];
+function renderAlertLog(){
+  const el=q('#alert-log');
+  if(!el) return;
+  el.innerHTML='';
+  alertLog.forEach(line=>{
+    const div=document.createElement('div');
+    div.textContent=line;
+    el.append(div);
+  });
+}
+window.onerror=(msg,src,line,col,err)=>{
+  alertLog.push(`${msg} (${src}:${line})`);
+  renderAlertLog();
+};
+window.onunhandledrejection=e=>{
+  alertLog.push(`Unhandled: ${e.reason}`);
+  renderAlertLog();
+};
+
 // ===== Download / Retire =====
 function downloadLog(){ const st=Game.state; const text=(st.eventLog||[]).join('\n'); const blob=new Blob([text],{type:'text/plain'}); const url=URL.createObjectURL(blob); const a=document.createElement('a'); a.href=url; a.download='webcareergame-log.txt'; a.click(); URL.revokeObjectURL(url); }
 function retirePrompt(){ const st=Game.state; const c=q('#retire-content'); c.innerHTML=''; const box=document.createElement('div'); box.className='glass';
@@ -55,6 +76,8 @@ function wireEvents(){
   click('#btn-log', ()=>downloadLog());
   click('#close-match', ()=>q('#match-modal').removeAttribute('open'));
   click('#close-message', ()=>q('#message-modal').removeAttribute('open'));
+  click('#btn-alert-log', ()=>{ renderAlertLog(); q('#alert-log-modal').setAttribute('open',''); });
+  click('#close-alert-log', ()=>q('#alert-log-modal').removeAttribute('open'));
 }
 
 (function boot(){


### PR DESCRIPTION
## Summary
- rename team level constant to prevent runtime ReferenceError when starting a new game
- add error log modal and capture window errors
- include toggle button on landing page for quick access to the alert log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3a8d2514832da033ed832ca9d21b