### PR TITLE
feat: announce season start and centralize contract options

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -52,6 +52,7 @@ function wireEvents(){
       Game.newGame({name,age,origin,pos,alwaysPlay});
       renderAll();
       openMarket();
+      showPopup('Season start', `Season ${Game.state.season} has started.`);
     });
   }
   const click = (id, fn)=>{ const el=q(id); if(el) el.onclick=fn; };
@@ -105,6 +106,7 @@ function wireEvents(){
     Game.newGame(setup);
     renderAll();
     openMarket();
+    showPopup('Season start', `Season ${Game.state.season} has started.`);
     history.replaceState(null, '', location.pathname);
     return true;
   }

--- a/js/season.js
+++ b/js/season.js
@@ -119,8 +119,12 @@ function openSeasonEnd(){
     <div>League position: ${pos}/20 ${won?' - <span class="badge">CHAMPIONS</span>':''}</div>
     <div class="muted" style="margin-top:8px">${seasonStat}</div>
     <div class="muted" style="margin-top:4px">${careerStat}</div>
-    ${tableHtml}
-    <div style="margin-top:10px"><button class="btn primary" id="btn-next-season">Start next season</button>${offerRenew?' <button class="btn" id="btn-renew-contract">Renew contract</button>':''}</div>`;
+    <div id="season-actions" style="text-align:center;margin:10px 0">
+      <button class="btn primary" id="btn-next-season">Start next season</button>
+      <button class="btn" id="btn-contract-rework">Contract</button>
+      ${offerRenew?'<button class="btn" id="btn-renew-contract">Renew contract</button>':''}
+    </div>
+    ${tableHtml}`;
   c.append(box); q('#match-modal').setAttribute('open','');
 
   q('#btn-next-season').onclick=()=>{
@@ -210,7 +214,9 @@ function openSeasonEnd(){
     Game.log(`Season ${st.season} begins. Age ${st.player.age}. ${contractInfo}`);
     Game.state.auto=false; updateAutoBtn();
     Game.save(); renderAll();
+    showPopup('Season start', `Season ${st.season} has started.`);
   };
+  q('#btn-contract-rework').onclick=()=>{ q('#match-modal').removeAttribute('open'); openContractRework(); };
   if(offerRenew){ q('#btn-renew-contract').onclick=()=>renewContractOffer(); }
 }
 


### PR DESCRIPTION
## Summary
- Show popup announcing season start when beginning a career or new season
- Display Next Season and contract buttons prominently in season summary

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5241146c832db11e7a0c7a0d46ec