### PR TITLE
Open dev tools in separate window

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Developer tools</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <div class="container">
+    <div class="row column">
+      <button class="btn" id="dev-injure">Injure player (7d)</button>
+      <button class="btn" id="dev-heal">Heal player</button>
+      <button class="btn" id="dev-loan">Request loan</button>
+      <button class="btn" id="dev-offers">Transfer offers</button>
+    </div>
+  </div>
+  <script src="js/dev.js"></script>
+</body>
+</html>

--- a/js/dev.js
+++ b/js/dev.js
@@ -1,0 +1,50 @@
+(function(){
+  const Game = window.opener.Game;
+  const renderAll = window.opener.renderAll;
+  const showPopup = window.opener.showPopup;
+  const requestLoan = window.opener.requestLoan;
+  const openMarket = window.opener.openMarket;
+  const rollMarketOffers = window.opener.rollMarketOffers;
+
+  const q = sel => document.querySelector(sel);
+  const click = (id, fn) => { const el = q(id); if(el) el.onclick = fn; };
+
+  click('#dev-injure', () => {
+    const st = Game.state;
+    if(st.player){
+      st.player.injury = {type:'dev injury', days:7};
+      Game.log('Dev: forced injury');
+      Game.save();
+      renderAll();
+      showPopup('Dev tools','Player injured for 7 days.');
+    }
+  });
+
+  click('#dev-heal', () => {
+    const st = Game.state;
+    if(st.player){
+      st.player.injury = null;
+      Game.log('Dev: healed injury');
+      Game.save();
+      renderAll();
+      showPopup('Dev tools','Player healed.');
+    }
+  });
+
+  click('#dev-loan', () => {
+    if(Game.state.player){
+      requestLoan();
+    }
+  });
+
+  click('#dev-offers', () => {
+    const st = Game.state;
+    if(st.player){
+      st.player.transferListed = true;
+      st.lastOffers = rollMarketOffers(st.player);
+      Game.save();
+      renderAll();
+      openMarket();
+    }
+  });
+})();

--- a/js/main.js
+++ b/js/main.js
@@ -79,47 +79,7 @@ function wireEvents(){
   click('#close-message', ()=>q('#message-modal').removeAttribute('open'));
   click('#btn-alert-log', ()=>{ renderAlertLog(); q('#alert-log-modal').setAttribute('open',''); });
   click('#close-alert-log', ()=>q('#alert-log-modal').removeAttribute('open'));
-  click('#btn-dev', ()=>q('#dev-modal').setAttribute('open',''));
-  click('#close-dev', ()=>q('#dev-modal').removeAttribute('open'));
-  click('#dev-injure', ()=>{
-    const st=Game.state;
-    if(st.player){
-      st.player.injury={type:'dev injury',days:7};
-      Game.log('Dev: forced injury');
-      Game.save();
-      renderAll();
-      showPopup('Dev tools','Player injured for 7 days.');
-    }
-    q('#dev-modal').removeAttribute('open');
-  });
-  click('#dev-heal', ()=>{
-    const st=Game.state;
-    if(st.player){
-      st.player.injury=null;
-      Game.log('Dev: healed injury');
-      Game.save();
-      renderAll();
-      showPopup('Dev tools','Player healed.');
-    }
-    q('#dev-modal').removeAttribute('open');
-  });
-  click('#dev-loan', ()=>{
-    if(Game.state.player){
-      requestLoan();
-    }
-    q('#dev-modal').removeAttribute('open');
-  });
-  click('#dev-offers', ()=>{
-    const st=Game.state;
-    if(st.player){
-      st.player.transferListed=true;
-      st.lastOffers=rollMarketOffers(st.player);
-      Game.save();
-      renderAll();
-      openMarket();
-    }
-    q('#dev-modal').removeAttribute('open');
-  });
+  click('#btn-dev', ()=>window.open('dev.html','devtools','width=400,height=420'));
 }
 
   (function boot(){

--- a/old-index.html
+++ b/old-index.html
@@ -309,22 +309,6 @@
     </div>
   </dialog>
 
-  <!-- Developer modal -->
-  <dialog id="dev-modal" class="modal">
-    <div class="sheet">
-      <header class="brand sheet-head">
-        <div class="logo"></div><h1 class="sheet-title">Developer tools</h1>
-        <button class="btn ghost" id="close-dev">Close</button>
-      </header>
-      <div class="content">
-        <div class="row column">
-          <button class="btn" id="dev-injure">Injure player (7d)</button>
-          <button class="btn" id="dev-heal">Heal player</button>
-          <button class="btn" id="dev-loan">Request loan</button>
-          <button class="btn" id="dev-offers">Transfer offers</button>
-        </div>
-      </div>
-    </div>
-  </dialog>
+  <!-- Developer tools now open in a separate window -->
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Launch developer tools in their own pop-up window instead of using an in-page modal
- Implement standalone `dev.html` and `js/dev.js` for dev actions like injury, heal, loan, and transfer offers
- Remove old developer modal markup from the game page

## Testing
- `npm test` (fails: ENOENT no package.json)


------
https://chatgpt.com/codex/tasks/task_e_68aa5ce82a2c832d95ddf6dbadaf23de