### PR TITLE
Improve developer popup logging

### DIFF
--- a/js/dev.js
+++ b/js/dev.js
@@ -1,13 +1,36 @@
 (function(){
-  const Game = window.opener.Game;
-  const renderAll = window.opener.renderAll;
-  const showPopup = window.opener.showPopup;
-  const requestLoan = window.opener.requestLoan;
-  const openMarket = window.opener.openMarket;
-  const rollMarketOffers = window.opener.rollMarketOffers;
+  const prefix = '[Dev window]';
+  console.log(prefix,'loaded');
+
+  const opener = window.opener;
+  if(!opener){
+    console.error(prefix,'no opener window found; open from the game.');
+    return;
+  }
+  const Game = opener.Game;
+  const renderAll = opener.renderAll;
+  const showPopup = opener.showPopup;
+  const requestLoan = opener.requestLoan;
+  const openMarket = opener.openMarket;
+  const rollMarketOffers = opener.rollMarketOffers;
+
+  if(!Game || !renderAll || !showPopup || !requestLoan || !openMarket || !rollMarketOffers){
+    console.error(prefix,'required functions missing on opener');
+    return;
+  }
 
   const q = sel => document.querySelector(sel);
-  const click = (id, fn) => { const el = q(id); if(el) el.onclick = fn; };
+  const click = (id, fn) => {
+    const el = q(id);
+    if(el) el.addEventListener('click', () => {
+      console.log(prefix,id,'clicked');
+      try {
+        fn();
+      } catch(err){
+        console.error(prefix,'error executing',id,err);
+      }
+    });
+  };
 
   click('#dev-injure', () => {
     const st = Game.state;


### PR DESCRIPTION
## Summary
- log when the developer tools window loads and buttons are clicked
- handle missing opener and missing functions gracefully

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5ec83120832da153fcd45648bfe4