### PR TITLE
Add La Liga and Serie A leagues with dynamic season lengths

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -56,6 +56,50 @@ const TEAM_BASE_LEVELS = {
   'Watford': 68,
   'West Brom': 69,
   'Wrexham': 65
+,
+  // La Liga 2025/26
+  'Alaves': 69,
+  'Athletic Club': 77,
+  'Atletico Madrid': 85,
+  'Barcelona': 88,
+  'Celta Vigo': 72,
+  'Cadiz': 68,
+  'Espanyol': 69,
+  'Getafe': 70,
+  'Girona': 72,
+  'Granada': 68,
+  'Las Palmas': 68,
+  'Mallorca': 70,
+  'Osasuna': 71,
+  'Rayo Vallecano': 70,
+  'Real Betis': 76,
+  'Real Madrid': 90,
+  'Real Sociedad': 80,
+  'Sevilla': 78,
+  'Valencia': 74,
+  'Villarreal': 78,
+
+  // Serie A 2025/26
+  'Atalanta': 84,
+  'Bologna': 78,
+  'Cagliari': 69,
+  'Empoli': 68,
+  'Fiorentina': 79,
+  'Genoa': 73,
+  'Hellas Verona': 71,
+  'Inter': 89,
+  'Juventus': 87,
+  'Lazio': 82,
+  'Lecce': 67,
+  'Milan': 86,
+  'Monza': 72,
+  'Napoli': 85,
+  'Parma': 70,
+  'Roma': 83,
+  'Salernitana': 68,
+  'Sassuolo': 74,
+  'Torino': 75,
+  'Udinese': 72
 };
 
 const Game = {
@@ -143,8 +187,9 @@ const Game = {
     this.state.leagueSnapshotWeek = 0;
     this.state.seasonSummary = null;
     const year = new Date().getFullYear();
+    const league = 'Premier League';
     const first = realisticMatchDate(lastSaturdayOfAugust(year));
-    this.state.schedule = buildSchedule(first, 38, null, 'Premier League');
+    this.state.schedule = buildSchedule(first, leagueWeeks(league), null, league);
     // start at season start marker day for clarity
     this.state.currentDate = this.state.schedule[0].date;
     this.log(`Career started: ${this.state.player.name}, ${this.state.player.age}, ${this.state.player.pos}, ${this.state.player.origin}`);

--- a/js/market.js
+++ b/js/market.js
@@ -144,7 +144,7 @@ function acceptOffer(i){
 
   const year=new Date().getFullYear();
   const first=realisticMatchDate(lastSaturdayOfAugust(year));
-  st.schedule=buildSchedule(first,38,st.player.club,st.player.league);
+  st.schedule=buildSchedule(first,leagueWeeks(st.player.league),st.player.club,st.player.league);
   st.currentDate=st.schedule[0].date;
   st.week=1;
   Game.log(`Signed for ${o.club}${st.player.loan?` (loaned to ${st.player.club})`:''}, ${o.years}y, ${o.status}, ${o.timeBand}, ${Game.money(o.salary)}/w`);
@@ -165,7 +165,7 @@ function requestLoan(){
     st.lastOffers = [];
     const year=new Date().getFullYear();
     const first=realisticMatchDate(lastSaturdayOfAugust(year));
-    st.schedule=buildSchedule(first,38,st.player.club,st.player.league);
+    st.schedule=buildSchedule(first,leagueWeeks(st.player.league),st.player.club,st.player.league);
     st.currentDate=st.schedule[0].date;
     st.week=1;
     Game.log(`Loaned to ${loanClub} for ${loanYears} season${loanYears>1?'s':''}.`);

--- a/js/match.js
+++ b/js/match.js
@@ -249,7 +249,7 @@ function finishMatch(entry, minutes, mini){
   applyPostMatchGrowth(st, minutes, rating, goals, assists, true, oppGoals);
   st.player.value = Math.round(computeValue(st.player.overall, st.player.league||'Premier League', st.player.salary||1000));
   payWeekly(st);
-  st.week = Math.min(38, st.week+1);
+  st.week = Math.min(leagueWeeks(st.player.league||'Premier League'), st.week+1);
   const gaPart = rating==='DNP' ? '' : (st.player.pos==='Goalkeeper' ? `, CS${cleanSheet}` : `, G${goals}, A${assists}`);
   Game.log(`Match vs ${entry.opponent}: ${result} ${scoreline}, min ${minutes}, rat ${rating}${gaPart}`);
   const injury = maybeInjure('match', minutes);
@@ -315,7 +315,7 @@ function simulateMatch(entry){
   applyPostMatchGrowth(st, minutes, rating, goals, assists, false, oppGoals);
   st.player.value=Math.round(computeValue(st.player.overall, st.player.league||'Premier League', st.player.salary||1000));
   payWeekly(st);
-  st.week=Math.min(38, st.week+1);
+  st.week=Math.min(leagueWeeks(st.player.league||'Premier League'), st.week+1);
   const gaPart = rating==='DNP' ? '' : (st.player.pos==='Goalkeeper' ? `, CS${cleanSheet}` : `, G${goals}, A${assists}`);
   Game.log(`Match vs ${entry.opponent}: ${result} ${scoreline}, min ${minutes}, rat ${rating}${gaPart}`);
   const injury = maybeInjure('match', minutes);

--- a/js/time.js
+++ b/js/time.js
@@ -38,7 +38,8 @@ function nextDay(token){
   if(entry && entry.isMatch && !entry.played){
     if(st.player.club==='Free Agent'){
       showPopup('Match day', 'You need a club to play matches.');
-      st.week = Math.min(38, st.week+1);
+      const maxWeeks = leagueWeeks(st.player.league||'Premier League');
+      st.week = Math.min(maxWeeks, st.week+1);
       st.currentDate+=24*3600*1000; Game.save(); renderAll(); if(Game.state.auto) autoTick();
       return;
     }

--- a/js/ui.js
+++ b/js/ui.js
@@ -41,7 +41,9 @@ function renderAll(){
   q('#landing').style.display = onLanding ? 'grid' : 'none';
   q('#manager').style.display = onLanding ? 'none' : 'block';
   if(onLanding) return;
-  if(!(st.seasonProcessed && st.leagueSnapshotWeek===38)) updateLeagueSnapshot();
+  const league = st.player.league || 'Premier League';
+  const weeksTotal = leagueWeeks(league);
+  if(!(st.seasonProcessed && st.leagueSnapshotWeek===weeksTotal)) updateLeagueSnapshot();
 
   // Left info
   q('#v-name').textContent = st.player.name;
@@ -65,7 +67,7 @@ function renderAll(){
   }
 
   q('#v-season').textContent = st.season;
-  q('#v-week').textContent = `${Math.min(st.week,38)} / 38`;
+  q('#v-week').textContent = `${Math.min(st.week,weeksTotal)} / ${weeksTotal}`;
   q('#v-overall').textContent = st.player.overall;
   q('#v-playtime').textContent = `${st.minutesPlayed} min`;
   const weeklyIncome = weeklySalary(st.player)+(st.player.passiveIncome||0);
@@ -109,8 +111,9 @@ function renderAll(){
     const info = document.createElement('div');
     info.className='muted';
     info.style.fontSize='12px';
-    const finalFlag = st.seasonProcessed && st.leagueSnapshotWeek===38 ? ' (final)' : '';
-    info.textContent = `Table: ${pos}/20${finalFlag} • Leader ${leader.team} ${leader.pts} pts`;
+    const finalFlag = st.seasonProcessed && st.leagueSnapshotWeek===weeksTotal ? ' (final)' : '';
+    const teamCount = makeOpponents(league).length;
+    info.textContent = `Table: ${pos}/${teamCount}${finalFlag} • Leader ${leader.team} ${leader.pts} pts`;
     q('#week-summary').append(info);
   }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -17,12 +17,29 @@ const LEAGUES = {
     'Millwall','Norwich City','Oxford United','Portsmouth','Preston North End',
     'Queens Park Rangers','Sheffield Utd','Sheffield Wednesday','Southampton','Stoke City',
     'Swansea City','Watford','West Brom','Wrexham'
+  ],
+  'La Liga': [
+    'Alaves','Athletic Club','Atletico Madrid','Barcelona','Celta Vigo',
+    'Cadiz','Espanyol','Getafe','Girona','Granada',
+    'Las Palmas','Mallorca','Osasuna','Rayo Vallecano','Real Betis',
+    'Real Madrid','Real Sociedad','Sevilla','Valencia','Villarreal'
+  ],
+  'Serie A': [
+    'Atalanta','Bologna','Cagliari','Empoli','Fiorentina',
+    'Genoa','Hellas Verona','Inter','Juventus','Lazio',
+    'Lecce','Milan','Monza','Napoli','Parma',
+    'Roma','Salernitana','Sassuolo','Torino','Udinese'
   ]
 };
 
 const CLUB_TO_LEAGUE = {};
 Object.entries(LEAGUES).forEach(([lg,teams])=>teams.forEach(t=>{CLUB_TO_LEAGUE[t]=lg;}));
 const ALL_CLUBS = Object.entries(LEAGUES).flatMap(([lg,teams])=>teams.map(t=>({club:t,league:lg})));
+
+function leagueWeeks(league){
+  const teams = LEAGUES[league] || LEAGUES['Premier League'];
+  return (teams.length - 1) * 2;
+}
 
 function getTeamLevel(club){
   return (Game.state.teamLevels && Game.state.teamLevels[club]) || TEAM_BASE_LEVELS[club] || 60;


### PR DESCRIPTION
## Summary
- Add La Liga and Serie A to league data and compute season length via new `leagueWeeks` helper
- Provide base strength ratings for all new clubs and seed schedules using `leagueWeeks`
- Update game flow and UI to respect varying league sizes across seasons, transfers and matches

## Testing
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
global.Game={state:{teamLevels:{}}};
vm.runInThisContext(fs.readFileSync('js/utils.js','utf8'));
vm.runInThisContext(fs.readFileSync('js/game.js','utf8'));
vm.runInThisContext(fs.readFileSync('js/market.js','utf8'));
const player = {overall:82, age:25, pos:'Attacker', club:'Free Agent'};
const offers = rollMarketOffers(player);
console.log('Offer count:', offers.length);
console.log('Sample clubs:', offers.map(o=>o.club).slice(0,5));
NODE`
- `node - <<'NODE'
const fs=require('fs');
const vm=require('vm');
global.Game={state:{teamLevels:{}}};
vm.runInThisContext(fs.readFileSync('js/utils.js','utf8'));
vm.runInThisContext(fs.readFileSync('js/game.js','utf8'));
const schedLaLiga = buildSchedule(new Date(2025,7,30), leagueWeeks('La Liga'), null, 'La Liga');
const schedChamp = buildSchedule(new Date(2025,7,30), leagueWeeks('EFL Championship'), null, 'EFL Championship');
console.log('Matches La Liga schedule:', schedLaLiga.filter(e=>e.isMatch).length);
console.log('Matches Championship schedule:', schedChamp.filter(e=>e.isMatch).length);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ab556223d8832d815f33a39d0a9734