### PR TITLE
Fix league table popup

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -63,7 +63,7 @@ function wireEvents(){
   click('#close-market', ()=>q('#market-modal').removeAttribute('open'));
   click('#close-shop', ()=>q('#shop-modal').removeAttribute('open'));
   click('#close-contract', ()=>q('#contract-modal').removeAttribute('open'));
-  click('#close-league', ()=>q('#league-modal').removeAttribute('open'));
+  click('#close-league', ()=>{ const dlg=q('#league-modal'); if(dlg){ if(dlg.close) dlg.close(); else dlg.removeAttribute('open'); } });
   click('#btn-next', ()=>nextDay());
   click('#btn-auto', ()=>toggleAuto());
   click('#btn-train', ()=>openTraining());

--- a/js/season.js
+++ b/js/season.js
@@ -89,7 +89,8 @@ function openLeagueTable(){
   content.append(select);
   content.append(tableWrap);
   render();
-  modal.setAttribute('open','');
+  if(modal.showModal) modal.showModal();
+  else modal.setAttribute('open','');
 }
 
 // ===== Season end summary & rollover =====


### PR DESCRIPTION
## Summary
- Ensure the league table modal opens via `showModal` when supported
- Close the league dialog using its `close()` method

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5a67c40c832d90ac5e3aa0a4b857