### PR TITLE
feat: add developer fast skip controls

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -119,6 +119,16 @@ function wireEvents(){
       openMarket();
     }
   });
+  click('#dev-skip-month', ()=>{
+    skipMonth();
+    Game.log('Dev: skipped month');
+    showPopup('Dev tools','Skipped one month.');
+  });
+  click('#dev-skip-season', ()=>{
+    skipSeason();
+    Game.log('Dev: skipped season');
+    showPopup('Dev tools','Skipped to season end.');
+  });
   click('#dev-set-balance', ()=>{
     const st=Game.state;
     const val=+q('#dev-balance').value;

--- a/js/match.js
+++ b/js/match.js
@@ -276,7 +276,7 @@ function finishMatch(entry, minutes, mini){
   if(injury) showPopup('Injury', `You suffered a ${injury.type} and will be out for ${injury.days} days.`);
 }
 
-function simulateMatch(entry){
+function simulateMatch(entry, fast=false){
   const st=Game.state;
   if(st.player.club==='Free Agent'){ showPopup('Match day', 'You need a club to play matches.'); return; }
   if(entry.played || !sameDay(entry.date, st.currentDate)) return;
@@ -321,7 +321,11 @@ function simulateMatch(entry){
   const injury = maybeInjure('match', minutes);
   Game.save(); renderAll();
   if(injury) showPopup('Injury', `You suffered a ${injury.type} and will be out for ${injury.days} days.`);
-  setTimeout(()=>{ nextDay(); },300);
+  if(fast){
+    nextDay(undefined, true);
+  } else {
+    setTimeout(()=>{ nextDay(); },300);
+  }
 }
 
 function viewMatchSummary(entry){

--- a/old-index.html
+++ b/old-index.html
@@ -334,6 +334,8 @@
           <button class="btn" id="dev-heal">Heal player</button>
           <button class="btn" id="dev-loan">Request loan</button>
           <button class="btn" id="dev-offers">Transfer offers</button>
+          <button class="btn" id="dev-skip-month">Skip month</button>
+          <button class="btn" id="dev-skip-season">Skip season</button>
           <div class="row">
             <input id="dev-balance" type="number" placeholder="Balance (£)">
             <button class="btn" id="dev-set-balance">Set balance</button>


### PR DESCRIPTION
## Summary
- add Skip month and Skip season buttons to developer tools modal
- support fast-forwarding day and match simulation
- expose helper functions to jump ahead by month or season

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5cef14e8832db5a3984a08535c72