### PR TITLE
Fix season end crash after skipping season

### DIFF
--- a/js/season.js
+++ b/js/season.js
@@ -113,6 +113,7 @@ function openSeasonEnd(){
 
     const club=st.player.club;
     const teams=makeOpponents(st.player.league||'Premier League').map(t=>({team:t}));
+    const games = leagueWeeks(st.player.league||'Premier League');
     if(!teams.find(t=>t.team===club)){ teams.pop(); teams.push({team:club}); }
     teams.forEach(t=>{
       if(t.team===club){ Object.assign(t,stats); }


### PR DESCRIPTION
## Summary
- define `games` when generating season summary to avoid ReferenceError

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/season.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab60675454832d9e9611645a86e515