### PR TITLE
Fix season skip to show summary

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -72,16 +72,18 @@ function skipMonth(){
 
 function skipSeason(){
   let guard=0;
+  let seasonEnded=false;
   while(guard<400){
     const st=Game.state;
     const entry=st.schedule.find(d=>sameDay(d.date, st.currentDate));
     if(entry && entry.type==='seasonEnd'){
       nextDay(undefined, true);
+      seasonEnded=true;
       break;
     }
     nextDay(undefined, true);
     guard++;
   }
-  renderAll();
+  if(!seasonEnded) renderAll();
 }
 


### PR DESCRIPTION
## Summary
- prevent skipSeason from overriding season summary UI

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab629d04e0832d99fc8195f931c125