### PR TITLE
Close dev tools modal when skipping a season

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -126,6 +126,7 @@ function wireEvents(){
   });
   click('#dev-skip-season', ()=>{
     skipSeason();
+    q('#dev-modal').removeAttribute('open');
     Game.log('Dev: skipped season');
     showPopup('Dev tools','Skipped to season end.');
   });


### PR DESCRIPTION
## Summary
- Close the developer tools dialog after using the Skip Season button so the season summary can be interacted with.

## Testing
- `node --check js/main.js`
- `node --check js/time.js`


------
https://chatgpt.com/codex/tasks/task_e_68ab651412dc832da50df1de2022adb1