### PR TITLE
Add dev button to force start new season

### DIFF
--- a/game.html
+++ b/game.html
@@ -336,6 +336,7 @@
           <button class="btn" id="dev-offers">Transfer offers</button>
           <button class="btn" id="dev-skip-month">Skip month</button>
           <button class="btn" id="dev-skip-season">Skip season</button>
+          <button class="btn" id="dev-force-season">Start next season</button>
           <div class="row">
             <input id="dev-balance" type="number" placeholder="Balance (£)">
             <button class="btn" id="dev-set-balance">Set balance</button>

--- a/js/main.js
+++ b/js/main.js
@@ -130,6 +130,12 @@ function wireEvents(){
     Game.log('Dev: skipped season');
     showPopup('Dev tools','Skipped to season end.');
   });
+  click('#dev-force-season', ()=>{
+    startNextSeason();
+    q('#dev-modal').removeAttribute('open');
+    Game.log('Dev: forced new season');
+    showPopup('Dev tools','Started next season.');
+  });
   click('#dev-set-balance', ()=>{
     const st=Game.state;
     const val=+q('#dev-balance').value;


### PR DESCRIPTION
## Summary
- Add `Start next season` button to developer tools modal
- Extract season rollover logic into reusable `startNextSeason` function
- Wire developer button to trigger season start even if season end is bugged

## Testing
- `node --check js/season.js`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab663b800c832d81b23d09323c341a