### PR TITLE
Add next season button on season end day

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -70,7 +70,15 @@ function wireEvents(){
   click('#close-training', ()=>cancelTraining());
   click('#close-cooldown', ()=>q('#cooldown-modal').removeAttribute('open'));
   click('#cooldown-ok', ()=>q('#cooldown-modal').removeAttribute('open'));
-  click('#btn-play', ()=>{ const entry=Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate)); if(entry && entry.isMatch && !entry.played) openMatch(entry); });
+  click('#btn-play', ()=>{
+    const entry=Game.state.schedule.find(d=>sameDay(d.date, Game.state.currentDate));
+    if(!entry) return;
+    if(entry.isMatch && !entry.played){
+      openMatch(entry);
+    } else if(entry.type==='seasonEnd'){
+      startNextSeason();
+    }
+  });
   click('#btn-save', ()=>{ Game.save(); showPopup('Save', 'Game saved'); });
   click('#btn-reset', ()=>{ showPopup('Reset save', 'Delete your local save and restart?', ()=>Game.reset()); });
   click('#btn-retire', ()=>retirePrompt());

--- a/js/ui.js
+++ b/js/ui.js
@@ -134,11 +134,20 @@ function renderAll(){
 
   const playBtn=q('#btn-play');
   if(playBtn){
-    if(st.player.club==='Free Agent') playBtn.disabled=true;
+    if(todayEntry && todayEntry.type==='seasonEnd'){
+      playBtn.disabled=false;
+      playBtn.textContent='Next season';
+    }
+    else if(st.player.club==='Free Agent'){
+      playBtn.disabled=true;
+      playBtn.textContent='Play match';
+    }
     else if(todayEntry && todayEntry.isMatch && !todayEntry.played && !st.auto && !autoTimeoutId && !st.player.injury){
       playBtn.disabled=false;
+      playBtn.textContent='Play match';
     } else {
       playBtn.disabled=true;
+      playBtn.textContent='Play match';
     }
   }
 


### PR DESCRIPTION
## Summary
- Enable starting next season directly from main screen when season end day arrives
- Set Play Match button to Next season on season end and handle click to start new season

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab6751a634832d9ab7c205ed5ed38f