### PR TITLE
Fix season summary and enable next season

### DIFF
--- a/js/season.js
+++ b/js/season.js
@@ -249,13 +249,13 @@ function openSeasonEnd(){
     }).join('');
     const tableHtml=`<table class="league-table"><thead><tr><th>Pos</th><th>Team</th><th>W</th><th>D</th><th>L</th><th>GF</th><th>GA</th><th>Pts</th></tr></thead><tbody>${rows}</tbody></table>`;
 
-    st.seasonSummary = {teams,pos,won,tableHtml};
+    st.seasonSummary = {teams,pos,totalTeams,won,tableHtml};
     st.seasonProcessed=true;
     Game.save();
     renderAll();
   }
 
-  const {pos,won,tableHtml} = st.seasonSummary;
+  const {pos,won,totalTeams,tableHtml} = st.seasonSummary;
   const offerRenew = st.player.club!=='Free Agent' && st.player.yearsLeft<=1;
 
   const c=q('#match-content'); c.innerHTML='';


### PR DESCRIPTION
## Summary
- Store total team count in season summary and include in destructured data.
- Fix season summary rendering so the Start next season button appears.

## Testing
- `node --check js/season.js && echo OK`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab68ce3ecc832da8765249fde2c66a