### PR TITLE
fix: restore player status after injury

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -203,6 +203,7 @@ function maybeInjure(source, minutes=0){
   else if(roll<0.9){ type='sprain'; days=randInt(7,21); }
   else { type='fracture'; days=randInt(30,90); }
   st.player.injury={type, days};
+  st.player.preInjuryStatus=st.player.status;
   st.player.status=`Injured (${type}, ${days}d)`;
   Game.log(`Injury: ${type}, out ${days} days`);
   return {type,days};

--- a/js/time.js
+++ b/js/time.js
@@ -50,7 +50,12 @@ function nextDay(token, fast=false){
     st.player.injury.days -= 1;
     if(st.player.injury.days<=0){
       st.player.injury=null;
-      st.player.status='-';
+      if(st.player.preInjuryStatus){
+        st.player.status=st.player.preInjuryStatus;
+        delete st.player.preInjuryStatus;
+      } else {
+        st.player.status='-';
+      }
       Game.log('Recovered from injury.');
       showPopup('Recovery', 'You are fit to play again.');
     } else {


### PR DESCRIPTION
## Summary
- keep player's previous status when injured and reinstate it upon recovery

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7406756c832db322575bf764309b