### PR TITLE
Add color palette sample buttons to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,21 @@
       </div>
     </section>
 
+    <section class="palette container">
+      <h2>Color options</h2>
+      <div class="color-options">
+        <button class="color-btn" style="background-color:#36454F" title="Charcoal"></button>
+        <button class="color-btn" style="background-color:#014421" title="Deep forest green"></button>
+        <button class="color-btn" style="background-color:#556B2F" title="Muted olive"></button>
+        <button class="color-btn" style="background-color:#5D3A1A" title="Warm walnut brown"></button>
+        <button class="color-btn" style="background-color:#4A2A16" title="Mahogany"></button>
+        <button class="color-btn" style="background-color:#191970" title="Midnight navy"></button>
+        <button class="color-btn" style="background-color:#3A497D" title="Slate blue"></button>
+        <button class="color-btn" style="background-color:#7C634B" title="Muted bronze"></button>
+        <button class="color-btn" style="background-color:#B87333" title="Brushed copper"></button>
+      </div>
+    </section>
+
     <section id="features" class="features container">
       <h2>What you'll do</h2>
       <div class="grid">

--- a/landing.css
+++ b/landing.css
@@ -88,6 +88,17 @@ body {
   color:var(--text-dim);
 }
 
+/* Color palette */
+.palette { padding:40px 0; text-align:center; }
+.color-options { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; }
+.color-btn {
+  width:32px;
+  height:32px;
+  border-radius:50%;
+  border:2px solid var(--surface);
+  cursor:pointer;
+}
+
 /* Player setup */
 .setup { padding:80px 0; }
 .field { display:grid; gap:6px; margin-bottom:12px; text-align:left; }


### PR DESCRIPTION
## Summary
- Add color preview buttons showcasing charcoal, green, brown, blue, and bronze tones
- Style color palette section to display small circular swatches

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68abb5e353c0832da8ae5f8be05468be