### PR TITLE
Refactor event wiring and externalize landing logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>WebCareerGame – Build Your Football Story</title>
   <link rel="stylesheet" href="landing.css" />
+  <script src="js/landing.js" defer></script>
 </head>
 <body>
   <header class="site-header">
@@ -103,26 +104,6 @@
     </div>
   </footer>
 
-  <script>
-      const form = document.getElementById('setup-form');
-      if(form){
-        form.addEventListener('submit', e => {
-          e.preventDefault();
-          const mode = document.querySelector('input[name=mode]:checked').value;
-          if (mode === 'manager') {
-            location.href = 'managergame.html';
-            return;
-          }
-          const params = new URLSearchParams({
-            name: document.getElementById('name').value,
-            age: document.getElementById('age').value,
-            origin: document.getElementById('origin').value,
-            pos: document.querySelector('input[name=pos]:checked').value,
-            alwaysPlay: document.getElementById('always-play').checked ? '1' : '0'
-          });
-          location.href = 'game.html?' + params.toString();
-        });
-      }
-  </script>
+
 </body>
 </html>

--- a/js/landing.js
+++ b/js/landing.js
@@ -1,0 +1,31 @@
+// Handles the landing page interactions and player setup.
+// This keeps the index.html page free from inline scripts and
+// makes the behaviour easier to maintain.
+(function(){
+  const form = document.getElementById('setup-form');
+  if(form){
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const mode = document.querySelector('input[name=mode]:checked').value;
+      if(mode === 'manager'){
+        location.href = 'managergame.html';
+        return;
+      }
+      const params = new URLSearchParams({
+        name: document.getElementById('name').value,
+        age: document.getElementById('age').value,
+        origin: document.getElementById('origin').value,
+        pos: document.querySelector('input[name=pos]:checked').value,
+        alwaysPlay: document.getElementById('always-play').checked ? '1' : '0'
+      });
+      location.href = 'game.html?' + params.toString();
+    });
+  }
+
+  // Allow quick theme colour switching on the landing page.
+  document.querySelectorAll('.color-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      document.documentElement.style.setProperty('--primary', btn.style.backgroundColor);
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- streamline event setup via a shared `bind` helper and split developer tools into a dedicated wiring function
- remove inline JavaScript from `index.html` and move logic into new `js/landing.js`
- allow quick landing page theme colour switching

## Testing
- `node -c js/main.js`
- `node -c js/landing.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add3c65abc832d81dfc6ca2d11cdaf