### PR TITLE
Remove colour options from landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,21 +30,6 @@
       </div>
     </section>
 
-    <section class="palette container">
-      <h2>Color options</h2>
-      <div class="color-options">
-        <button class="color-btn" style="background-color:#36454F" title="Charcoal"></button>
-        <button class="color-btn" style="background-color:#014421" title="Deep forest green"></button>
-        <button class="color-btn" style="background-color:#556B2F" title="Muted olive"></button>
-        <button class="color-btn" style="background-color:#5D3A1A" title="Warm walnut brown"></button>
-        <button class="color-btn" style="background-color:#4A2A16" title="Mahogany"></button>
-        <button class="color-btn" style="background-color:#191970" title="Midnight navy"></button>
-        <button class="color-btn" style="background-color:#3A497D" title="Slate blue"></button>
-        <button class="color-btn" style="background-color:#7C634B" title="Muted bronze"></button>
-        <button class="color-btn" style="background-color:#B87333" title="Brushed copper"></button>
-      </div>
-    </section>
-
     <section id="features" class="features container">
       <h2>What you'll do</h2>
       <div class="grid">

--- a/js/landing.js
+++ b/js/landing.js
@@ -22,10 +22,4 @@
     });
   }
 
-  // Allow quick theme colour switching on the landing page.
-  document.querySelectorAll('.color-btn').forEach(btn => {
-    btn.addEventListener('click', () => {
-      document.documentElement.style.setProperty('--primary', btn.style.backgroundColor);
-    });
-  });
 })();

--- a/landing.css
+++ b/landing.css
@@ -88,17 +88,6 @@ body {
   color:var(--text-dim);
 }
 
-/* Color palette */
-.palette { padding:40px 0; text-align:center; }
-.color-options { display:flex; flex-wrap:wrap; gap:8px; justify-content:center; }
-.color-btn {
-  width:32px;
-  height:32px;
-  border-radius:50%;
-  border:2px solid var(--surface);
-  cursor:pointer;
-}
-
 /* Player setup */
 .setup { padding:80px 0; }
 .field { display:grid; gap:6px; margin-bottom:12px; text-align:left; }


### PR DESCRIPTION
## Summary
- remove colour palette section from landing page
- drop unused styles and script for colour switching

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68add5eb0d74832db1eea68b14fdd9d1