### PR TITLE
feat: add carabao cup competition

### DIFF
--- a/js/league.js
+++ b/js/league.js
@@ -59,6 +59,7 @@ function openLeagueTable(){
   const content=q('#league-content');
   if(!modal || !content) return;
   const leagues=Object.keys(LEAGUES);
+  leagues.push('Carabao Cup');
   const select=document.createElement('select');
   leagues.forEach(lg=>{
     const opt=document.createElement('option');
@@ -71,7 +72,15 @@ function openLeagueTable(){
   function render(){
     const lg=select.value;
     let teams;
-    if(st.player && st.player.league===lg){
+    if(lg==='Carabao Cup'){
+      const cup=(st.schedule||[]).filter(e=>e.competition==='Carabao Cup');
+      const rows=cup.map(e=>{
+        const res=e.played?`${e.result}${e.scoreline?` ${e.scoreline}`:''}`:'TBD';
+        return `<tr><td>${e.round||''}</td><td>${e.opponent}</td><td>${res}</td></tr>`;
+      }).join('');
+      tableWrap.innerHTML=`<table class="league-table"><thead><tr><th>Round</th><th>Opponent</th><th>Result</th></tr></thead><tbody>${rows}</tbody></table>`;
+      return;
+    } else if(st.player && st.player.league===lg){
       updateLeagueSnapshot();
       teams=(st.leagueSnapshot||[]).slice();
     } else {

--- a/js/match.js
+++ b/js/match.js
@@ -253,6 +253,13 @@ function finishMatch(entry, minutes, mini){
   st.week = Math.min(leagueWeeks(st.player.league||'Premier League'), st.week+1);
   const gaPart = rating==='DNP' ? '' : (st.player.pos==='Goalkeeper' ? `, CS${cleanSheet}` : `, G${goals}, A${assists}`);
   Game.log(`Match vs ${entry.opponent}: ${result} ${scoreline}, min ${minutes}, rat ${rating}${gaPart}`);
+  if(entry.competition==='Carabao Cup'){
+    if(entry.round==='Final' && result==='W'){
+      Game.log('🏆 Carabao Cup won!');
+      showPopup('Trophy', 'You won the Carabao Cup!');
+    }
+    if(result!=='W') eliminateCup('Carabao Cup');
+  }
   const injury = maybeInjure('match', minutes);
 
   // Move day and show summary
@@ -319,6 +326,13 @@ function simulateMatch(entry, fast=false){
   st.week=Math.min(leagueWeeks(st.player.league||'Premier League'), st.week+1);
   const gaPart = rating==='DNP' ? '' : (st.player.pos==='Goalkeeper' ? `, CS${cleanSheet}` : `, G${goals}, A${assists}`);
   Game.log(`Match vs ${entry.opponent}: ${result} ${scoreline}, min ${minutes}, rat ${rating}${gaPart}`);
+  if(entry.competition==='Carabao Cup'){
+    if(entry.round==='Final' && result==='W'){
+      Game.log('🏆 Carabao Cup won!');
+      showPopup('Trophy', 'You won the Carabao Cup!');
+    }
+    if(result!=='W') eliminateCup('Carabao Cup');
+  }
   const injury = maybeInjure('match', minutes);
   Game.save(); renderAll();
   if(injury) showPopup('Injury', `You suffered a ${injury.type} and will be out for ${injury.days} days.`);

--- a/js/ui.js
+++ b/js/ui.js
@@ -174,7 +174,11 @@ function renderCalendar(){
     if(entry){
       if(entry.type==='seasonStart') label='<div style="font-size:11px">Season start</div>';
       else if(entry.type==='seasonEnd') label='<div style="font-size:11px">Season end</div>';
-      else if(entry.isMatch) label=`<div style="font-size:11px;">vs ${entry.opponent}</div><div style="font-size:10px">${entry.competition||'League'} game</div>`;
+      else if(entry.isMatch){
+        let comp=entry.competition||'League';
+        if(entry.competition==='Carabao Cup' && entry.round) comp+=` ${entry.round}`;
+        label=`<div style="font-size:11px;">vs ${entry.opponent}</div><div style="font-size:10px">${comp} game</div>`;
+      }
     }
     item.innerHTML=`<div class="muted">${dateStr}</div><div class="dot"></div>${label}${extra||''}`;
 


### PR DESCRIPTION
## Summary
- schedule Carabao Cup rounds for English leagues
- track cup progress and elimination
- show cup matches and results in calendar and table view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68adde17a670832da07ac81b7501adcb