### PR TITLE
feat: hide Carabao Cup finalists

### DIFF
--- a/game.html
+++ b/game.html
@@ -34,15 +34,18 @@
 		<script
 			src="js/match.js"
 			defer></script>
-		<script
-			src="js/season.js"
-			defer></script>
-		<script
-			src="js/league.js"
-			defer></script>
-		<script
-			src="js/time.js"
-			defer></script>
+                <script
+                        src="js/season.js"
+                        defer></script>
+                <script
+                        src="js/carabao.js"
+                        defer></script>
+                <script
+                        src="js/league.js"
+                        defer></script>
+                <script
+                        src="js/time.js"
+                        defer></script>
 		<script
 			src="js/main.js"
 			defer></script>

--- a/js/carabao.js
+++ b/js/carabao.js
@@ -1,0 +1,9 @@
+// ===== Carabao Cup helpers =====
+function renderCarabaoCupTable(matches){
+  const rows = matches.map(e=>{
+    const opponent = e.played ? e.opponent : 'TBD';
+    const res = e.played ? `${e.result}${e.scoreline?` ${e.scoreline}`:''}` : 'TBD';
+    return `<tr><td>${e.round||''}</td><td>${opponent}</td><td>${res}</td></tr>`;
+  }).join('');
+  return `<table class="league-table"><thead><tr><th>Round</th><th>Opponent</th><th>Result</th></tr></thead><tbody>${rows}</tbody></table>`;
+}

--- a/js/league.js
+++ b/js/league.js
@@ -74,11 +74,7 @@ function openLeagueTable(){
     let teams;
     if(lg==='Carabao Cup'){
       const cup=(st.schedule||[]).filter(e=>e.competition==='Carabao Cup');
-      const rows=cup.map(e=>{
-        const res=e.played?`${e.result}${e.scoreline?` ${e.scoreline}`:''}`:'TBD';
-        return `<tr><td>${e.round||''}</td><td>${e.opponent}</td><td>${res}</td></tr>`;
-      }).join('');
-      tableWrap.innerHTML=`<table class="league-table"><thead><tr><th>Round</th><th>Opponent</th><th>Result</th></tr></thead><tbody>${rows}</tbody></table>`;
+      tableWrap.innerHTML=renderCarabaoCupTable(cup);
       return;
     } else if(st.player && st.player.league===lg){
       updateLeagueSnapshot();


### PR DESCRIPTION
## Summary
- add dedicated Carabao Cup helper to hide future opponents
- render cup table via helper to avoid revealing final in league modal
- load Carabao Cup helper script in game page

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ade45e3a48832da3c3d570523ed64c