### PR TITLE
Show season and career playtime with match counts

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -110,11 +110,13 @@ const Game = {
     currentDate: null,
     schedule: [],
     minutesPlayed: 0,
+    matchesPlayed: 0,
     goals: 0,
     assists: 0,
     cleanSheets: 0,
     seasonCleanSheets: 0,
     seasonMinutes: 0,
+    seasonMatches: 0,
     seasonGoals: 0,
     seasonAssists: 0,
     lastOffers: [],
@@ -164,8 +166,8 @@ const Game = {
       injury: null,
     };
     this.state.season = 1; this.state.week = 1;
-    this.state.minutesPlayed = 0; this.state.goals = 0; this.state.assists = 0; this.state.cleanSheets = 0;
-    this.state.seasonMinutes = 0; this.state.seasonGoals = 0; this.state.seasonAssists = 0; this.state.seasonCleanSheets = 0;
+    this.state.minutesPlayed = 0; this.state.matchesPlayed = 0; this.state.goals = 0; this.state.assists = 0; this.state.cleanSheets = 0;
+    this.state.seasonMinutes = 0; this.state.seasonMatches = 0; this.state.seasonGoals = 0; this.state.seasonAssists = 0; this.state.seasonCleanSheets = 0;
     this.state.lastOffers = []; this.state.playedMatchDates = []; this.state.eventLog = [];
     this.state.shopPurchases = {};
     this.state.auto = false;

--- a/js/match.js
+++ b/js/match.js
@@ -245,9 +245,10 @@ function finishMatch(entry, minutes, mini){
   // Commit outcome
   entry.played=true; entry.result=result; entry.scoreline=scoreline; Game.state.playedMatchDates.push(entry.date);
   const cleanSheet = st.player.pos==='Goalkeeper' && oppGoals===0 ? 1 : 0;
-  st.minutesPlayed+=minutes; st.goals+=goals; st.assists+=assists; if(st.player.pos==='Goalkeeper') st.cleanSheets+=cleanSheet;
-  st.seasonMinutes+=minutes; st.seasonGoals+=goals; st.seasonAssists+=assists; if(st.player.pos==='Goalkeeper') st.seasonCleanSheets+=cleanSheet;
-  applyPostMatchGrowth(st, minutes, rating, goals, assists, true, oppGoals);
+    st.minutesPlayed+=minutes; st.goals+=goals; st.assists+=assists; if(st.player.pos==='Goalkeeper') st.cleanSheets+=cleanSheet;
+    st.seasonMinutes+=minutes; st.seasonGoals+=goals; st.seasonAssists+=assists; if(st.player.pos==='Goalkeeper') st.seasonCleanSheets+=cleanSheet;
+    if(minutes>0){ st.matchesPlayed++; st.seasonMatches++; }
+    applyPostMatchGrowth(st, minutes, rating, goals, assists, true, oppGoals);
   st.player.value = Math.round(computeValue(st.player.overall, st.player.league||'Premier League', st.player.salary||1000));
   payWeekly(st);
   st.week = Math.min(leagueWeeks(st.player.league||'Premier League'), st.week+1);
@@ -318,9 +319,10 @@ function simulateMatch(entry, fast=false){
   const scoreline=`${teamGoals}-${oppGoals}`;
   entry.played=true; entry.result=result; entry.scoreline=scoreline; Game.state.playedMatchDates.push(entry.date);
   const cleanSheet = st.player.pos==='Goalkeeper' && oppGoals===0 ? 1 : 0;
-  st.minutesPlayed+=minutes; st.goals+=goals; st.assists+=assists; if(st.player.pos==='Goalkeeper') st.cleanSheets+=cleanSheet;
-  st.seasonMinutes+=minutes; st.seasonGoals+=goals; st.seasonAssists+=assists; if(st.player.pos==='Goalkeeper') st.seasonCleanSheets+=cleanSheet;
-  applyPostMatchGrowth(st, minutes, rating, goals, assists, false, oppGoals);
+    st.minutesPlayed+=minutes; st.goals+=goals; st.assists+=assists; if(st.player.pos==='Goalkeeper') st.cleanSheets+=cleanSheet;
+    st.seasonMinutes+=minutes; st.seasonGoals+=goals; st.seasonAssists+=assists; if(st.player.pos==='Goalkeeper') st.seasonCleanSheets+=cleanSheet;
+    if(minutes>0){ st.matchesPlayed++; st.seasonMatches++; }
+    applyPostMatchGrowth(st, minutes, rating, goals, assists, false, oppGoals);
   st.player.value=Math.round(computeValue(st.player.overall, st.player.league||'Premier League', st.player.salary||1000));
   payWeekly(st);
   st.week=Math.min(leagueWeeks(st.player.league||'Premier League'), st.week+1);

--- a/js/season.js
+++ b/js/season.js
@@ -84,7 +84,7 @@ function startNextSeason(){
   const league = st.player.league || 'Premier League';
   st.schedule = buildSchedule(first, leagueWeeks(league), st.player.club, league);
   st.currentDate = st.schedule[0].date; // on season start marker
-  st.seasonMinutes=0; st.seasonGoals=0; st.seasonAssists=0; st.seasonCleanSheets=0;
+  st.seasonMinutes=0; st.seasonMatches=0; st.seasonGoals=0; st.seasonAssists=0; st.seasonCleanSheets=0;
   Object.keys(st.shopPurchases||{}).forEach(id=>{ const it=SHOP_ITEMS.find(i=>i.id===id); if(it && it.perSeason) delete st.shopPurchases[id]; });
   st.player.salaryMultiplier=1;
   st.seasonProcessed = false;

--- a/js/ui.js
+++ b/js/ui.js
@@ -69,7 +69,7 @@ function renderAll(){
   q('#v-season').textContent = st.season;
   q('#v-week').textContent = `${Math.min(st.week,weeksTotal)} / ${weeksTotal}`;
   q('#v-overall').textContent = st.player.overall;
-  q('#v-playtime').textContent = `${st.minutesPlayed} min`;
+  q('#v-playtime').textContent = `${st.seasonMinutes} min / ${st.seasonMatches} matches (${st.minutesPlayed} min / ${st.matchesPlayed} matches)`;
   const weeklyIncome = weeklySalary(st.player)+(st.player.passiveIncome||0);
   q('#v-salary').textContent = Game.money(weeklyIncome) + ' /week';
   q('#v-value').textContent = fmtValue(st.player.value);


### PR DESCRIPTION
## Summary
- Track matches played for career and season
- Reset and persist match counts across seasons and new games
- Display current season and career playtime with match totals in career panel

## Testing
- `node --check js/game.js js/season.js js/match.js js/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68adec95a090832daf6f312943c2d7b6