### PR TITLE
Add skill breakdown to player overall

### DIFF
--- a/game.html
+++ b/game.html
@@ -267,12 +267,16 @@
 									id="v-week"
 									>1 / 38</div
 								>
-								<div class="k">Overall</div
-								><div
-									class="v"
-									id="v-overall"
-									>—</div
-								>
+                                                                <div class="k">Overall</div
+                                                                ><div class="v">
+                                                                        <span id="v-overall">—</span>
+                                                                        <button class="btn small" id="btn-skills">Skills</button>
+                                                                </div>
+                                                                <div class="k skill-detail hidden">Shooting</div><div class="v skill-detail hidden" id="skill-shooting"></div>
+                                                                <div class="k skill-detail hidden">Passing</div><div class="v skill-detail hidden" id="skill-passing"></div>
+                                                                <div class="k skill-detail hidden">Dribbling</div><div class="v skill-detail hidden" id="skill-dribbling"></div>
+                                                                <div class="k skill-detail hidden">Defending</div><div class="v skill-detail hidden" id="skill-defending"></div>
+                                                                <div class="k skill-detail hidden">Goalkeeping</div><div class="v skill-detail hidden" id="skill-goalkeeping"></div>
 								<div class="k">Play time</div
 								><div
 									class="v"

--- a/js/game.js
+++ b/js/game.js
@@ -104,7 +104,7 @@ const TEAM_BASE_LEVELS = {
 const Game = {
   state: {
     // player fields get filled on newGame
-    player: null, // {name, age, origin, pos, overall, club, league, status, timeBand, salary, value, balance, yearsLeft, transferListed, alwaysPlay, goldenClub, releaseClause, marketBlocked, contractReworkYear, loan}
+    player: null, // {name, age, origin, pos, overall, skills, club, league, status, timeBand, salary, value, balance, yearsLeft, transferListed, alwaysPlay, goldenClub, releaseClause, marketBlocked, contractReworkYear, loan}
     season: 1,
     week: 1,
     currentDate: null,
@@ -137,14 +137,15 @@ const Game = {
   reset(){ location.reload(); },
   log(msg){ const stamp = new Date(this.state.currentDate || Date.now()).toDateString(); this.state.eventLog.push(`[${stamp}] ${msg}`); },
   newGame(setup){
-    const base = 55 + Math.floor(Math.random()*6);
-    const overall = Math.min(60, base + (setup.pos==='Defender'?1:0));
+    const skills = generateSkills(setup.pos);
+    const overall = computeOverallFromSkills(skills);
     this.state.player = {
       name: setup.name.trim(),
       age: +setup.age,
       origin: setup.origin,
       pos: setup.pos,
       overall,
+      skills,
       club: 'Free Agent',
       league: '',
       status: '-',

--- a/js/main.js
+++ b/js/main.js
@@ -80,6 +80,7 @@ function wireCoreEvents(){
   bind('#btn-next', ()=>nextDay());
   bind('#btn-auto', ()=>toggleAuto());
   bind('#btn-train', ()=>openTraining());
+  bind('#btn-skills', ()=>toggleSkills());
   bind('#close-training', ()=>cancelTraining());
   bind('#close-cooldown', ()=>q('#cooldown-modal').removeAttribute('open'));
   bind('#cooldown-ok', ()=>q('#cooldown-modal').removeAttribute('open'));

--- a/js/match.js
+++ b/js/match.js
@@ -144,16 +144,26 @@ function openTraining(){
 function finishTraining(mini){
   const st=Game.state;
   const gain=+(mini.score*0.5).toFixed(2);
-  st.player.overall=Math.min(100, +(st.player.overall+gain).toFixed(2));
-  Game.log(`Training session: overall +${gain.toFixed(2)}`);
-  const notes=q('#notes'); if(notes) notes.textContent=`Trained today. Overall +${gain.toFixed(2)}.`;
+  const pre = st.player.overall;
+  if(st.player.skills){
+    const rel=relevantSkills(st.player.pos);
+    rel.forEach(k=>{
+      st.player.skills[k]=Math.min(100, +(st.player.skills[k]+gain).toFixed(2));
+    });
+    st.player.overall=computeOverallFromSkills(st.player.skills);
+  } else {
+    st.player.overall=Math.min(100, +(st.player.overall+gain).toFixed(2));
+  }
+  const delta=st.player.overall - pre;
+  Game.log(`Training session: overall +${delta.toFixed(2)}`);
+  const notes=q('#notes'); if(notes) notes.textContent=`Trained today. Overall +${delta.toFixed(2)}.`;
   st.lastTrainingDate = st.currentDate;
   const injury = maybeInjure('training');
   Game.save();
   renderAll();
-  setTimeout(()=>{ 
-    q('#training-modal').removeAttribute('open'); 
-    showPopup('Training complete', `Overall +${gain.toFixed(2)} (now ${st.player.overall.toFixed(2)})`);
+  setTimeout(()=>{
+    q('#training-modal').removeAttribute('open');
+    showPopup('Training complete', `Overall +${delta.toFixed(2)} (now ${st.player.overall.toFixed(2)})`);
     if(injury) setTimeout(()=>showPopup('Injury', `You suffered a ${injury.type} and will be out for ${injury.days} days.`), 600);
   }, 600);
 }

--- a/js/shop.js
+++ b/js/shop.js
@@ -1,10 +1,24 @@
 // ===== Shop =====
 const SHOP_ITEMS=[
-  {id:'trainer',name:'Personal Trainer',desc:'Gain +1 overall instantly',cost:500,limit:3,perSeason:true,apply:st=>{st.player.overall=Math.min(100,st.player.overall+1);}},
+  {id:'trainer',name:'Personal Trainer',desc:'Gain +1 to key skills',cost:500,limit:3,perSeason:true,apply:st=>{
+    if(st.player.skills){
+      relevantSkills(st.player.pos).forEach(k=>{ st.player.skills[k]=Math.min(100, st.player.skills[k]+1); });
+      st.player.overall=computeOverallFromSkills(st.player.skills);
+    } else {
+      st.player.overall=Math.min(100,st.player.overall+1);
+    }
+  }},
   {id:'boots',name:'Shiny Boots',desc:'Boost market value by £500',cost:250,limit:2,perSeason:true,apply:st=>{st.player.value+=500;}},
   {id:'sponsor',name:'Sponsorship Deal',desc:'Salary +10% for this season',cost:2000,limit:1,perSeason:true,apply:st=>{st.player.salaryMultiplier=(st.player.salaryMultiplier||1)*1.1;}},
   {id:'house',name:'Small House',desc:'Earn £100 weekly income forever',cost:10000,limit:3,perSeason:false,apply:st=>{st.player.passiveIncome=(st.player.passiveIncome||0)+100; st.player.houses=(st.player.houses||0)+1;}},
-  {id:'gym',name:'Gym Membership',desc:'Improve overall by +2 this season',cost:1500,limit:1,perSeason:true,apply:st=>{st.player.overall=Math.min(100,st.player.overall+2);}},
+  {id:'gym',name:'Gym Membership',desc:'Improve key skills by +2 this season',cost:1500,limit:1,perSeason:true,apply:st=>{
+    if(st.player.skills){
+      relevantSkills(st.player.pos).forEach(k=>{ st.player.skills[k]=Math.min(100, st.player.skills[k]+2); });
+      st.player.overall=computeOverallFromSkills(st.player.skills);
+    } else {
+      st.player.overall=Math.min(100,st.player.overall+2);
+    }
+  }},
   {id:'car',name:'Sports Car',desc:'Raise value by £2000',cost:3000,limit:1,perSeason:true,apply:st=>{st.player.value+=2000;}}
 ];
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -35,9 +35,21 @@ function showCooldownPopup(rest){
   }
 }
 
+function toggleSkills(){
+  const btn=q('#btn-skills');
+  const rows=[...document.querySelectorAll('.skill-detail')];
+  if(!rows.length) return;
+  const hidden=rows[0].classList.contains('hidden');
+  rows.forEach(r=>{ hidden ? r.classList.remove('hidden') : r.classList.add('hidden'); });
+  if(btn) btn.textContent = hidden ? 'Hide skills' : 'Skills';
+}
+
 // ===== Rendering =====
 function renderAll(){
   const st = Game.state; const onLanding = !st.player;
+  if(st.player && st.player.skills){
+    st.player.overall = computeOverallFromSkills(st.player.skills);
+  }
   q('#landing').style.display = onLanding ? 'grid' : 'none';
   q('#manager').style.display = onLanding ? 'none' : 'block';
   if(onLanding) return;
@@ -69,6 +81,11 @@ function renderAll(){
   q('#v-season').textContent = st.season;
   q('#v-week').textContent = `${Math.min(st.week,weeksTotal)} / ${weeksTotal}`;
   q('#v-overall').textContent = st.player.overall;
+  const skills = st.player.skills || {};
+  ['shooting','passing','dribbling','defending','goalkeeping'].forEach(s=>{
+    const el=q('#skill-'+s);
+    if(el) el.textContent = skills[s];
+  });
   q('#v-playtime').textContent = `${st.seasonMinutes} min / ${st.seasonMatches} matches (${st.minutesPlayed} min / ${st.matchesPlayed} matches)`;
   const weeklyIncome = weeklySalary(st.player)+(st.player.passiveIncome||0);
   q('#v-salary').textContent = Game.money(weeklyIncome) + ' /week';


### PR DESCRIPTION
## Summary
- compute player overall from position-based skills
- add expandable skills view next to overall rating
- train, shop and growth now improve relevant skills

## Testing
- `node --check js/utils.js`
- `node --check js/game.js`
- `node --check js/match.js`
- `node --check js/shop.js`
- `node --check js/ui.js`
- `node --check js/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2e01357c832daa05ebb366017986