### PR TITLE
Improve league table realism with probabilistic simulation

### DIFF
--- a/js/league.js
+++ b/js/league.js
@@ -1,54 +1,82 @@
+// ===== Helper functions for league simulation =====
+function poissonRandom(lambda){
+  let L=Math.exp(-lambda),k=0,p=1;
+  do{ k++; p*=Math.random(); }while(p>L);
+  return k-1;
+}
+
+function teamStrength(club){
+  const lvl=TEAM_BASE_LEVELS[club] || 70;
+  return (lvl-70)/40; // roughly -0.25..0.5
+}
+
+function shuffle(arr){
+  for(let i=arr.length-1;i>0;i--){
+    const j=Math.floor(Math.random()*(i+1));
+    [arr[i],arr[j]]=[arr[j],arr[i]];
+  }
+}
+
+function buildFixtures(clubs){
+  const teams=clubs.slice();
+  shuffle(teams);
+  const n=teams.length;
+  const rounds=[];
+  for(let r=0;r<n-1;r++){
+    const week=[];
+    for(let i=0;i<n/2;i++){
+      week.push({home:teams[i], away:teams[n-1-i]});
+    }
+    rounds.push(week);
+    teams.splice(1,0,teams.pop()); // rotate
+  }
+  const returnRounds=rounds.map(week=>week.map(m=>({home:m.away, away:m.home})));
+  return rounds.concat(returnRounds);
+}
+
 // ===== League snapshot during season =====
 function updateLeagueSnapshot(){
   const st=Game.state;
   if(!st.player || st.player.club==='Free Agent') return;
-  // Don't overwrite the final league table once the season is processed
-  const gamesTotal = leagueWeeks(st.player.league||'Premier League');
+  const gamesTotal=leagueWeeks(st.player.league||'Premier League');
   if(st.seasonProcessed && st.leagueSnapshotWeek===gamesTotal) return;
-  const played = st.schedule.filter(e=>e.isMatch && e.played).length;
+  const played=st.schedule.filter(e=>e.isMatch && e.played).length;
   if(st.leagueSnapshotWeek===played) return;
-    const club=st.player.club;
-    const teams=makeOpponents(st.player.league||'Premier League').map(t=>({team:t}));
-    const games = leagueWeeks(st.player.league||'Premier League');
-    const stats={w:0,d:0,l:0,gf:0,ga:0};
+  const league=st.player.league||'Premier League';
+  const club=st.player.club;
+  const teams=randomLeagueTable(league, played);
+  const stats={w:0,d:0,l:0,gf:0,ga:0};
   st.schedule.filter(e=>e.isMatch && e.played).forEach(e=>{
-    if(e.result==='W') stats.w++;
-    else if(e.result==='D') stats.d++;
-    else stats.l++;
+    if(e.result==='W') stats.w++; else if(e.result==='D') stats.d++; else stats.l++;
     if(e.scoreline){ const [gf,ga]=e.scoreline.split('-').map(Number); stats.gf+=gf; stats.ga+=ga; }
   });
   stats.pts=stats.w*3+stats.d;
-  teams.forEach(t=>{
-    if(t.team===club){ Object.assign(t,stats); }
-    else {
-      const lvl=getTeamLevel(t.team);
-      const w=randInt(0, Math.min(played, Math.round(played*(0.2+lvl/200))));
-      const d=randInt(0, Math.min(played-w, Math.round(played*0.3)));
-      const l=played-w-d;
-      const gf=w*randInt(1,3)+d*randInt(0,2)+randInt(0,5);
-      const ga=l*randInt(1,3)+d*randInt(0,2)+randInt(0,5);
-      const pts=w*3+d;
-      Object.assign(t,{w,d,l,gf,ga,pts});
-    }
-  });
-  teams.sort((a,b)=>b.pts-a.pts || (b.gf-b.ga)-(a.gf-a.ga));
+  const idx=teams.findIndex(t=>t.team===club);
+  if(idx>=0) Object.assign(teams[idx],stats);
   st.leagueSnapshot=teams;
   st.leagueSnapshotWeek=played;
   Game.save();
 }
 
 function randomLeagueTable(league, played){
-  const teams=makeOpponents(league).map(t=>({team:t}));
-  teams.forEach(t=>{
-    const lvl=getTeamLevel(t.team);
-    const w=randInt(0, Math.min(played, Math.round(played*(0.2+lvl/200))));
-    const d=randInt(0, Math.min(played-w, Math.round(played*0.3)));
-    const l=played-w-d;
-    const gf=w*randInt(1,3)+d*randInt(0,2)+randInt(0,5);
-    const ga=l*randInt(1,3)+d*randInt(0,2)+randInt(0,5);
-    const pts=w*3+d;
-    Object.assign(t,{w,d,l,gf,ga,pts});
-  });
+  const clubs=makeOpponents(league);
+  const fixtures=buildFixtures(clubs);
+  const teams=clubs.map(c=>({team:c,w:0,d:0,l:0,gf:0,ga:0,pts:0}));
+  const map=Object.fromEntries(teams.map(t=>[t.team,t]));
+  const weeks=Math.min(played, fixtures.length);
+  for(let r=0;r<weeks;r++){
+    fixtures[r].forEach(({home,away})=>{
+      const sh=teamStrength(home);
+      const sa=teamStrength(away);
+      const gh=poissonRandom(Math.exp(sh-sa+0.15));
+      const ga=poissonRandom(Math.exp(sa-sh));
+      const h=map[home], a=map[away];
+      h.gf+=gh; h.ga+=ga; a.gf+=ga; a.ga+=gh;
+      if(gh>ga){ h.w++; a.l++; h.pts+=3; }
+      else if(gh<ga){ a.w++; h.l++; a.pts+=3; }
+      else { h.d++; a.d++; h.pts++; a.pts++; }
+    });
+  }
   teams.sort((a,b)=>b.pts-a.pts || (b.gf-b.ga)-(a.gf-a.ga));
   return teams;
 }


### PR DESCRIPTION
## Summary
- simulate league seasons using probabilistic Poisson model based on team strength
- update league snapshot to use new simulation for more realistic standings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae59bedc68832d831d8550fb346823