### PR TITLE
Cache league fixtures and refine goal model

### DIFF
--- a/js/league.js
+++ b/js/league.js
@@ -1,37 +1,59 @@
 // ===== Helper functions for league simulation =====
-function poissonRandom(lambda){
+function createRNG(seed){
+  let s=seed>>>0;
+  return function(){
+    s=(s*1664525+1013904223)>>>0;
+    return s/4294967296;
+  };
+}
+
+function poissonRandom(lambda, rand=Math.random){
   let L=Math.exp(-lambda),k=0,p=1;
-  do{ k++; p*=Math.random(); }while(p>L);
+  do{ k++; p*=rand(); }while(p>L);
   return k-1;
 }
 
 function teamStrength(club){
   const lvl=TEAM_BASE_LEVELS[club] || 70;
-  return (lvl-70)/40; // roughly -0.25..0.5
+  return (lvl-70)/60; // roughly -0.16..0.33
 }
 
-function shuffle(arr){
+function shuffle(arr, rand=Math.random){
   for(let i=arr.length-1;i>0;i--){
-    const j=Math.floor(Math.random()*(i+1));
+    const j=Math.floor(rand()*(i+1));
     [arr[i],arr[j]]=[arr[j],arr[i]];
   }
 }
 
-function buildFixtures(clubs){
+function buildFixtures(clubs, rand=Math.random){
   const teams=clubs.slice();
-  shuffle(teams);
+  if(teams.length%2===1) teams.push('BYE');
+  shuffle(teams, rand);
   const n=teams.length;
   const rounds=[];
   for(let r=0;r<n-1;r++){
     const week=[];
     for(let i=0;i<n/2;i++){
-      week.push({home:teams[i], away:teams[n-1-i]});
+      const home=teams[i], away=teams[n-1-i];
+      if(home!=='BYE' && away!=='BYE') week.push({home, away});
     }
     rounds.push(week);
     teams.splice(1,0,teams.pop()); // rotate
   }
   const returnRounds=rounds.map(week=>week.map(m=>({home:m.away, away:m.home})));
   return rounds.concat(returnRounds);
+}
+
+function getFixtures(league){
+  const st=Game.state;
+  st.leagueFixtures = st.leagueFixtures || {};
+  st.leagueSeeds = st.leagueSeeds || {};
+  if(!st.leagueFixtures[league]){
+    const clubs=makeOpponents(league);
+    st.leagueSeeds[league]=Math.floor(Math.random()*1e9);
+    st.leagueFixtures[league]=buildFixtures(clubs);
+  }
+  return st.leagueFixtures[league];
 }
 
 // ===== League snapshot during season =====
@@ -43,6 +65,7 @@ function updateLeagueSnapshot(){
   const played=st.schedule.filter(e=>e.isMatch && e.played).length;
   if(st.leagueSnapshotWeek===played) return;
   const league=st.player.league||'Premier League';
+  getFixtures(league);
   const club=st.player.club;
   const teams=randomLeagueTable(league, played);
   const stats={w:0,d:0,l:0,gf:0,ga:0};
@@ -59,17 +82,37 @@ function updateLeagueSnapshot(){
 }
 
 function randomLeagueTable(league, played){
+  const st=Game.state;
   const clubs=makeOpponents(league);
-  const fixtures=buildFixtures(clubs);
+  const fixtures=getFixtures(league);
   const teams=clubs.map(c=>({team:c,w:0,d:0,l:0,gf:0,ga:0,pts:0}));
   const map=Object.fromEntries(teams.map(t=>[t.team,t]));
+  const rand=createRNG(st.leagueSeeds[league]||0);
+
+  // apply real results to fixtures
+  if(st.schedule){
+    st.schedule.filter(e=>e.isMatch && e.played && e.competition==='League').forEach(e=>{
+      const [gf,ga]=e.scoreline.split('-').map(Number);
+      const club=st.player.club;
+      let match=fixtures.flat().find(m=>m.home===club && m.away===e.opponent && m.gh==null);
+      if(match){ match.gh=gf; match.ga=ga; }
+      else {
+        match=fixtures.flat().find(m=>m.home===e.opponent && m.away===club && m.gh==null);
+        if(match){ match.gh=ga; match.ga=gf; }
+      }
+    });
+  }
+
   const weeks=Math.min(played, fixtures.length);
   for(let r=0;r<weeks;r++){
-    fixtures[r].forEach(({home,away})=>{
+    fixtures[r].forEach(m=>{
+      const {home,away}=m;
       const sh=teamStrength(home);
       const sa=teamStrength(away);
-      const gh=poissonRandom(Math.exp(sh-sa+0.15));
-      const ga=poissonRandom(Math.exp(sa-sh));
+      const lambdaHome=1.30*Math.exp(0.15+(sh-sa));
+      const lambdaAway=1.30*Math.exp(sa-sh);
+      const gh=m.gh!=null?m.gh:poissonRandom(lambdaHome, rand);
+      const ga=m.ga!=null?m.ga:poissonRandom(lambdaAway, rand);
       const h=map[home], a=map[away];
       h.gf+=gh; h.ga+=ga; a.gf+=ga; a.ga+=gh;
       if(gh>ga){ h.w++; a.l++; h.pts+=3; }
@@ -77,7 +120,7 @@ function randomLeagueTable(league, played){
       else { h.d++; a.d++; h.pts++; a.pts++; }
     });
   }
-  teams.sort((a,b)=>b.pts-a.pts || (b.gf-b.ga)-(a.gf-a.ga));
+  teams.sort((a,b)=>b.pts-a.pts || (b.gf-b.ga)-(a.gf-a.ga) || b.gf-a.gf || a.team.localeCompare(b.team));
   return teams;
 }
 

--- a/js/season.js
+++ b/js/season.js
@@ -93,6 +93,8 @@ function startNextSeason(){
   st.seasonSummary = null;
   st.leagueSnapshot = [];
   st.leagueSnapshotWeek = 0;
+  st.leagueFixtures = {};
+  st.leagueSeeds = {};
   const contractInfo = st.player.club==='Free Agent'
     ? 'Free Agent.'
     : `Contract ${st.player.yearsLeft} season${st.player.yearsLeft!==1?'s':''} left.`;


### PR DESCRIPTION
## Summary
- cache league fixtures and use seeded RNG for consistent simulations
- compress team strength scale and apply calibrated expected goals model
- handle odd team counts and proper tie-breakers in league tables

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ae5db0ea8c832d973a07b953cfbb8c