### PR TITLE
Ensure season summary buttons are accessible on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -613,16 +613,19 @@ a {
 	display: flex;
 }
 .modal .sheet {
-	width: 100%;
-	max-width: 760px;
-	background: linear-gradient(180deg, #0f141b, #121923);
-	border: 1px solid var(--border);
-	border-radius: 16px;
-	box-shadow: 0 40px 80px rgba(0, 0, 0, 0.6);
-	color: var(--text);
+        width: 100%;
+        max-width: 760px;
+        background: linear-gradient(180deg, #0f141b, #121923);
+        border: 1px solid var(--border);
+        border-radius: 16px;
+        box-shadow: 0 40px 80px rgba(0, 0, 0, 0.6);
+        color: var(--text);
+        max-height: 100%;
+        display: flex;
+        flex-direction: column;
 }
 #shop-modal .sheet {
-	max-width: 900px;
+        max-width: 900px;
 }
 .sheet-head {
 	padding: 10px 16px;
@@ -631,12 +634,14 @@ a {
 	font-size: 16px;
 }
 .sheet .content {
-	padding: 16px;
+        padding: 16px;
+        overflow-y: auto;
+        flex: 1;
 }
 .sheet-actions {
-	display: flex;
-	justify-content: flex-end;
-	gap: 8px;
+        display: flex;
+        justify-content: flex-end;
+        gap: 8px;
 	padding-top: 0;
 }
 #contract-salary-info {


### PR DESCRIPTION
## Summary
- Limit modal height and make content scrollable
- Keep season summary buttons visible on small displays

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/webfccareermode/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68af709aff4c832da904d7fadd0571a3