### PR TITLE
Fix league table not showing at season start

### DIFF
--- a/js/league.js
+++ b/js/league.js
@@ -63,8 +63,8 @@ function updateLeagueSnapshot(){
   if(!st.player || st.player.club==='Free Agent') return;
   const gamesTotal=leagueWeeks(st.player.league||'Premier League');
   if(st.seasonProcessed && st.leagueSnapshotWeek===gamesTotal) return;
-  const played=st.schedule.filter(e=>e.isMatch && e.played).length;
-  if(st.leagueSnapshotWeek===played) return;
+  const played=(st.schedule||[]).filter(e=>e.isMatch && e.played).length;
+  if(st.leagueSnapshot && st.leagueSnapshot.length>0 && st.leagueSnapshotWeek===played) return;
   const league=st.player.league||'Premier League';
   getFixtures(league);
   const club=st.player.club;


### PR DESCRIPTION
## Summary
- ensure updateLeagueSnapshot always builds snapshot on first run
- guard schedule access when computing played matches

## Testing
- `node --check js/league.js`


------
https://chatgpt.com/codex/tasks/task_e_68af76e056a0832dbc6c151766a9d520