### PR TITLE
Fix contract length rollover handling

### DIFF
--- a/js/contract.js
+++ b/js/contract.js
@@ -143,7 +143,7 @@ function openContractRework(){
     const chance=contractChance(st,salary,years,status,time);
     if(Math.random()<chance){
       st.player.salary=Math.round(salary);
-      st.player.yearsLeft=years+1;
+      st.player.yearsLeft=years;
       st.player.status=status;
       st.player.timeBand=time;
       st.player.releaseClause=Math.round(st.player.value*(1.2+years*0.1));

--- a/js/market.js
+++ b/js/market.js
@@ -122,7 +122,7 @@ function acceptOffer(i){
   const o=Game.state.lastOffers[i]; const st=Game.state;
   st.player.club=o.club; st.player.league=o.league; st.player.status=o.status; st.player.timeBand=o.timeBand;
   st.player.salary=Math.round(o.salary); st.player.value=Math.round(o.value);
-  st.player.yearsLeft=o.years+1; st.player.transferListed=false; st.lastOffers=[];
+  st.player.yearsLeft=o.years; st.player.transferListed=false; st.lastOffers=[];
   st.player.releaseClause=Math.round((o.releaseClauseFee?o.releaseClauseFee:o.value)*1.5);
   st.player.marketBlocked=0; st.player.contractReworkYear=0;
   if(o.releaseClauseFee) Game.log(`Release clause of ${Game.money(o.releaseClauseFee)} activated by ${o.club}`);

--- a/js/season.js
+++ b/js/season.js
@@ -28,21 +28,6 @@ function startNextSeason(){
     }
     showPopup('Manager', msg);
     Game.log(`Manager: ${msg}`);
-
-    st.player.yearsLeft = Math.max(0, st.player.yearsLeft-1);
-    if(st.player.yearsLeft<=0){
-      st.player.club='Free Agent';
-      st.player.league='';
-      st.player.status='-';
-      st.player.timeBand='-';
-      st.player.salary=0;
-      st.player.yearsLeft=0;
-      st.player.releaseClause=0;
-      st.player.marketBlocked=0;
-      Game.log('Contract ended. You are a Free Agent.');
-    } else {
-      st.player.marketBlocked = Math.max(0,(st.player.marketBlocked||0)-1);
-    }
     const poorSeason = st.player.pos==='Goalkeeper'
       ? lastSeason.min>900 && lastSeason.cleanSheets<4
       : lastSeason.min>900 && (lastSeason.goals+lastSeason.assists)<2;
@@ -106,6 +91,24 @@ function startNextSeason(){
 }
 function openSeasonEnd(){
   const st=Game.state;
+  if(!st.seasonProcessed){
+    if(st.player.club!=='Free Agent'){
+      st.player.yearsLeft = Math.max(0,(st.player.yearsLeft||0)-1);
+      if(st.player.yearsLeft<=0){
+        st.player.club='Free Agent';
+        st.player.league='';
+        st.player.status='-';
+        st.player.timeBand='-';
+        st.player.salary=0;
+        st.player.yearsLeft=0;
+        st.player.releaseClause=0;
+        st.player.marketBlocked=0;
+        Game.log('Contract ended. You are a Free Agent.');
+      } else {
+        st.player.marketBlocked = Math.max(0,(st.player.marketBlocked||0)-1);
+      }
+    }
+  }
   if(!st.seasonSummary){
     // compute player's team stats from season
     const stats={w:0,d:0,l:0,gf:0,ga:0};
@@ -281,7 +284,7 @@ function renewContractOffer(){
       st.player.status=o.status;
       st.player.timeBand=o.time;
       st.player.salary=o.salary;
-      st.player.yearsLeft=o.years+1;
+      st.player.yearsLeft=o.years;
       st.player.marketBlocked=o.marketBlocked;
       st.player.releaseClause=o.releaseClause;
       Game.log(o.log);

--- a/js/utils.js
+++ b/js/utils.js
@@ -38,7 +38,7 @@ const ALL_CLUBS = Object.entries(LEAGUES).flatMap(([lg,teams])=>teams.map(t=>({c
 
 function visibleYearsLeft(p){
   p = p || Game.state.player;
-  return Math.max(0, (p.yearsLeft || 0) - 1);
+  return Math.max(0, p.yearsLeft || 0);
 }
 
 function leagueWeeks(league){


### PR DESCRIPTION
## Summary
- Handle contract expiration at season end instead of start of next season
- Store exact contract lengths without hidden extra year when signing or reworking deals
- Display correct remaining contract years

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af7dd828bc832db02a2b8840a2ead2