### PR TITLE
Fix contract countdown to start after season ends

### DIFF
--- a/js/contract.js
+++ b/js/contract.js
@@ -144,6 +144,7 @@ function openContractRework(){
     if(Math.random()<chance){
       st.player.salary=Math.round(salary);
       st.player.yearsLeft=years;
+      st.player.contractStartSeason=st.season+1;
       st.player.status=status;
       st.player.timeBand=time;
       st.player.releaseClause=Math.round(st.player.value*(1.2+years*0.1));

--- a/js/game.js
+++ b/js/game.js
@@ -104,7 +104,7 @@ const TEAM_BASE_LEVELS = {
 const Game = {
   state: {
     // player fields get filled on newGame
-    player: null, // {name, age, origin, pos, overall, skills, club, league, status, timeBand, salary, value, balance, yearsLeft, transferListed, alwaysPlay, goldenClub, releaseClause, marketBlocked, contractReworkYear, loan}
+    player: null, // {name, age, origin, pos, overall, skills, club, league, status, timeBand, salary, value, balance, yearsLeft, contractStartSeason, transferListed, alwaysPlay, goldenClub, releaseClause, marketBlocked, contractReworkYear, loan}
     season: 1,
     week: 1,
     currentDate: null,
@@ -157,6 +157,7 @@ const Game = {
       value: 0,
       balance: 0,
       yearsLeft: 0,
+      contractStartSeason: 0,
       transferListed: false,
       alwaysPlay: !!setup.alwaysPlay,
       goldenClub: false,

--- a/js/market.js
+++ b/js/market.js
@@ -122,7 +122,7 @@ function acceptOffer(i){
   const o=Game.state.lastOffers[i]; const st=Game.state;
   st.player.club=o.club; st.player.league=o.league; st.player.status=o.status; st.player.timeBand=o.timeBand;
   st.player.salary=Math.round(o.salary); st.player.value=Math.round(o.value);
-  st.player.yearsLeft=o.years; st.player.transferListed=false; st.lastOffers=[];
+  st.player.yearsLeft=o.years; st.player.contractStartSeason=st.season+1; st.player.transferListed=false; st.lastOffers=[];
   st.player.releaseClause=Math.round((o.releaseClauseFee?o.releaseClauseFee:o.value)*1.5);
   st.player.marketBlocked=0; st.player.contractReworkYear=0;
   if(o.releaseClauseFee) Game.log(`Release clause of ${Game.money(o.releaseClauseFee)} activated by ${o.club}`);

--- a/js/season.js
+++ b/js/season.js
@@ -93,7 +93,9 @@ function openSeasonEnd(){
   const st=Game.state;
   if(!st.seasonProcessed){
     if(st.player.club!=='Free Agent'){
-      st.player.yearsLeft = Math.max(0,(st.player.yearsLeft||0)-1);
+      if(st.season >= (st.player.contractStartSeason || 0)){
+        st.player.yearsLeft = Math.max(0,(st.player.yearsLeft||0)-1);
+      }
       if(st.player.yearsLeft<=0){
         st.player.club='Free Agent';
         st.player.league='';
@@ -103,6 +105,7 @@ function openSeasonEnd(){
         st.player.yearsLeft=0;
         st.player.releaseClause=0;
         st.player.marketBlocked=0;
+        st.player.contractStartSeason=0;
         Game.log('Contract ended. You are a Free Agent.');
       } else {
         st.player.marketBlocked = Math.max(0,(st.player.marketBlocked||0)-1);
@@ -285,6 +288,7 @@ function renewContractOffer(){
       st.player.timeBand=o.time;
       st.player.salary=o.salary;
       st.player.yearsLeft=o.years;
+      st.player.contractStartSeason=st.season+1;
       st.player.marketBlocked=o.marketBlocked;
       st.player.releaseClause=o.releaseClause;
       Game.log(o.log);


### PR DESCRIPTION
## Summary
- track contract start season and defer year decrement until a full season passes
- update all contract signing flows to record next season as the start

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af801bda00832dae9d346d46a24b86