### PR TITLE
Include pace and physical in overall rating

### DIFF
--- a/game.html
+++ b/game.html
@@ -276,8 +276,10 @@
                                                                 <div class="k skill-detail hidden">Passing</div><div class="v skill-detail hidden" id="skill-passing"></div>
                                                                 <div class="k skill-detail hidden">Dribbling</div><div class="v skill-detail hidden" id="skill-dribbling"></div>
                                                                 <div class="k skill-detail hidden">Defending</div><div class="v skill-detail hidden" id="skill-defending"></div>
+                                                                <div class="k skill-detail hidden">Pace</div><div class="v skill-detail hidden" id="skill-pace"></div>
+                                                                <div class="k skill-detail hidden">Physical</div><div class="v skill-detail hidden" id="skill-physical"></div>
                                                                 <div class="k skill-detail hidden">Goalkeeping</div><div class="v skill-detail hidden" id="skill-goalkeeping"></div>
-								<div class="k">Play time</div
+                                                                <div class="k">Play time</div
 								><div
 									class="v"
 									id="v-playtime"

--- a/js/ui.js
+++ b/js/ui.js
@@ -83,7 +83,7 @@ function renderAll(){
   q('#v-week').textContent = `${Math.min(st.week,weeksTotal)} / ${weeksTotal}`;
   q('#v-overall').textContent = st.player.overall;
   const skills = st.player.skills || {};
-  ['shooting','passing','dribbling','defending','goalkeeping'].forEach(s=>{
+  ['shooting','passing','dribbling','defending','pace','physical','goalkeeping'].forEach(s=>{
     const el=q('#skill-'+s);
     if(el) el.textContent = skills[s];
   });

--- a/js/utils.js
+++ b/js/utils.js
@@ -164,7 +164,9 @@ function generateSkills(pos){
         passing: rand(40,60),
         dribbling: rand(30,50),
         defending: rand(40,60),
-        goalkeeping: rand(65,75)
+        goalkeeping: rand(65,75),
+        pace: rand(30,50),
+        physical: rand(60,70)
       };
       break;
     case 'Defender':
@@ -173,7 +175,9 @@ function generateSkills(pos){
         passing: rand(45,60),
         dribbling: rand(40,55),
         defending: rand(60,70),
-        goalkeeping: rand(5,15)
+        goalkeeping: rand(5,15),
+        pace: rand(55,65),
+        physical: rand(60,70)
       };
       break;
     case 'Midfield':
@@ -182,7 +186,9 @@ function generateSkills(pos){
         passing: rand(60,70),
         dribbling: rand(55,65),
         defending: rand(40,50),
-        goalkeeping: rand(5,15)
+        goalkeeping: rand(5,15),
+        pace: rand(60,70),
+        physical: rand(50,60)
       };
       break;
     default: // Attacker
@@ -191,7 +197,9 @@ function generateSkills(pos){
         passing: rand(50,60),
         dribbling: rand(55,65),
         defending: rand(30,40),
-        goalkeeping: rand(5,15)
+        goalkeeping: rand(5,15),
+        pace: rand(65,75),
+        physical: rand(50,60)
       };
   }
 
@@ -209,13 +217,13 @@ function generateSkills(pos){
 function relevantSkills(pos){
   switch(pos){
     case 'Goalkeeper':
-      return ['goalkeeping','passing','defending'];
+      return ['goalkeeping','passing','defending','pace','physical'];
     case 'Defender':
-      return ['defending','passing','dribbling'];
+      return ['defending','passing','dribbling','pace','physical'];
     case 'Midfield':
-      return ['passing','dribbling','shooting','defending'];
+      return ['passing','dribbling','shooting','defending','pace','physical'];
     default:
-      return ['shooting','dribbling','passing'];
+      return ['shooting','dribbling','passing','pace','physical'];
   }
 }
 


### PR DESCRIPTION
## Summary
- Generate pace and physical skills for all player positions
- Expose pace and physical in relevant skill lists and UI
- Show pace and physical skill values in the game screen

## Testing
- `node --check js/utils.js`
- `node --check js/ui.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68af88177354832d872db2c866184404