### PR TITLE
Award full skill point when training

### DIFF
--- a/js/match.js
+++ b/js/match.js
@@ -172,7 +172,8 @@ function openMatch(entry){
 
 function finishTraining(mini){
   const st=Game.state;
-  const gain=+(mini.score*0.5).toFixed(2);
+  // Always award a full point per training session.
+  const gain=1;
   const pre = st.player.overall;
   const cap=s=>s.charAt(0).toUpperCase()+s.slice(1);
 
@@ -180,7 +181,8 @@ function finishTraining(mini){
     const chosen = (trainingSession && trainingSession.skills && trainingSession.skills.length)
       ? trainingSession.skills
       : relevantSkills(st.player.pos);
-    const per = (trainingSession && trainingSession.trainAll) ? +(gain/Math.max(1,chosen.length)).toFixed(2) : gain;
+    // Split the single point across all selected skills when training multiple.
+    const per = chosen.length>1 ? +(gain/Math.max(1,chosen.length)).toFixed(2) : gain;
     const display = chosen.map(cap);
     chosen.forEach(k=>{
       st.player.skills[k]=Math.min(100, +(st.player.skills[k]+per).toFixed(2));


### PR DESCRIPTION
## Summary
- always grant one full point to the chosen skill during training
- divide the point across all skills when training everything at once

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0dff19a88832da384e26d17f19860