### PR TITLE
fix: populate country select without helper

### DIFF
--- a/js/countries.js
+++ b/js/countries.js
@@ -213,9 +213,9 @@ const flagEmoji = code =>
   String.fromCodePoint(...[...code].map(c => 127397 + c.charCodeAt()));
 
 function setupCountrySelect(){
-  const cont=q('#continent');
-  const country=q('#country');
-  if(!cont||!country) return;
+  const cont = document.getElementById('continent');
+  const country = document.getElementById('country');
+  if(!cont || !country) return;
   function update(){
     const list=COUNTRIES[cont.value]||[];
     country.innerHTML='';


### PR DESCRIPTION
## Summary
- Remove dependency on `q` helper for country select
- Populate country dropdown using standard DOM methods

## Testing
- `node --check js/countries.js`


------
https://chatgpt.com/codex/tasks/task_e_68b367e325d8832d8973b19d968367d9