### PR TITLE
Schedule team training days

### DIFF
--- a/js/time.js
+++ b/js/time.js
@@ -45,6 +45,9 @@ function nextDay(token, fast=false){
     }
     simulateMatch(entry, fast); return;
   }
+  if(entry && entry.type==='training'){
+    simulateTraining();
+  }
   if(entry && entry.type==='seasonEnd'){ Game.state.auto=false; updateAutoBtn(); openSeasonEnd(); return; }
   if(st.player.injury){
     st.player.injury.days -= 1;

--- a/js/ui.js
+++ b/js/ui.js
@@ -119,6 +119,9 @@ function renderAll(){
   else if(todayEntry && todayEntry.isMatch){
     q('#week-summary').innerHTML = `Match day: ${st.player.club} vs ${todayEntry.opponent}<div class="muted" style="font-size:11px"></div>`;
   }
+  else if(todayEntry && todayEntry.type==='training'){
+    q('#week-summary').textContent = 'Team training day. Stay sharp.';
+  }
   else{
     q('#week-summary').textContent = 'Training and recovery. Prepare for the next game.';
   }
@@ -137,7 +140,7 @@ function renderAll(){
 
   const trainBtn=q('#btn-train');
   if(trainBtn){
-    trainBtn.disabled=!!st.player.injury;
+    trainBtn.disabled=!!st.player.injury || (todayEntry && todayEntry.type==='training');
   }
 
   const nextBtn=q('#btn-next');

--- a/js/utils.js
+++ b/js/utils.js
@@ -85,11 +85,22 @@ function buildSchedule(firstMatchDate, weeks, excludeClub, league){
   if(lg==='Premier League' || lg==='EFL Championship'){
     insertCarabaoCup(out, firstMatchDate, excludeClub);
   }
-  // season end marker two days after final match
+  // add fixed team training days every second day
   out.sort((a,b)=>a.date-b.date);
+  const seasonStartDate = out[0].date;
   const lastMatch = out.filter(e=>e.isMatch).slice(-1)[0];
   if(lastMatch){
     const end=new Date(lastMatch.date); end.setDate(end.getDate()+2);
+    let d=new Date(seasonStartDate); d.setDate(d.getDate()+1);
+    while(d.getTime()<=end.getTime()){
+      while(out.some(e=>sameDay(e.date,d.getTime()) && e.isMatch)){
+        d.setDate(d.getDate()+1);
+      }
+      if(!out.some(e=>sameDay(e.date,d.getTime()))){
+        out.push({date:d.getTime(), type:'training', isMatch:false, isTraining:true, played:true});
+      }
+      d.setDate(d.getDate()+2);
+    }
     out.push({date:end.getTime(), type:'seasonEnd', isMatch:false, played:true});
   }
   return out.sort((a,b)=>a.date-b.date);


### PR DESCRIPTION
## Summary
- insert automatic team training days every second day in the season schedule, moving off match days
- simulate team training sessions, skipping if injured
- surface team training in the UI and disable manual training on those days

## Testing
- `node --check js/utils.js`
- `node --check js/time.js`
- `node --check js/match.js`
- `node --check js/ui.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b36f5729d4832d8302e0b6694a7f90